### PR TITLE
Fix filename conversions for Windows

### DIFF
--- a/crytic_compile/utils/naming.py
+++ b/crytic_compile/utils/naming.py
@@ -1,5 +1,5 @@
 import platform
-from pathlib import Path, PureWindowsPath
+from pathlib import Path
 from collections import namedtuple
 from ..platform.exceptions import InvalidCompilation
 
@@ -35,10 +35,10 @@ def convert_filename(used_filename):
     filename = used_filename
     if platform.system() == 'Windows':
         elements = list(Path(filename).parts)
-        if elements[0] == '/':
+        if elements[0] == '/' or elements[0] == '\\':
             elements = elements[1:]  # remove '/'
             elements[0] = elements[0] + ':/'  # add :/
-        filename = PureWindowsPath(*elements)
+        filename = Path(*elements)
     else:
         filename = Path(filename)
 
@@ -51,5 +51,7 @@ def convert_filename(used_filename):
             raise InvalidCompilation(f'Unknown file: {filename}')
     elif not filename.is_absolute():
         filename = Path.cwd().joinpath(filename)
+
+    assert filename.exists(), f"Could not resolve filename: \"{used_filename}\""
 
     return Filename(absolute=str(filename), used = used_filename)

--- a/crytic_compile/utils/naming.py
+++ b/crytic_compile/utils/naming.py
@@ -52,6 +52,4 @@ def convert_filename(used_filename):
     elif not filename.is_absolute():
         filename = Path.cwd().joinpath(filename)
 
-    assert filename.exists(), f"Could not resolve filename: \"{used_filename}\""
-
     return Filename(absolute=str(filename), used = used_filename)


### PR DESCRIPTION
This pull request aims to resolve an issue where filename conversions on Windows would fail with the following error:
```
Traceback (most recent call last):
  File "C:\Python\Python37\Scripts\crytic-compile-script.py", line 11, in <module>
    load_entry_point('crytic-compile', 'console_scripts', 'crytic-compile')()
  File "c:\users\vyper\documents\github\crytic-compile\crytic_compile\__main__.py", line 77, in main
    cryticCompile = CryticCompile(**vars(args))
  File "c:\users\vyper\documents\github\crytic-compile\crytic_compile\crytic_compile.py", line 67, in __init__
    self._compile(target, **kwargs)
  File "c:\users\vyper\documents\github\crytic-compile\crytic_compile\crytic_compile.py", line 444, in _compile
    compile_truffle(self, target, **kwargs)
  File "c:\users\vyper\documents\github\crytic-compile\crytic_compile\platform\truffle.py", line 78, in compile
    filename = convert_filename(filename)
  File "c:\users\vyper\documents\github\crytic-compile\crytic_compile\utils\naming.py", line 45, in convert_filename
    if not filename.exists():
AttributeError: 'PureWindowsPath' object has no attribute 'exists'
```

The following changes were made:
- Changed `PureWindowsPath` to simply `Path`, as `PureWindowsPath` does not implement the `exists()` method, which was causing an error.
- Changed the first character `/` check on Windows to account for `\`. Although only `\` was encountered, it may help to handle both cases.

Tests were successfully conducted on `Windows 10 Enterprise 10.0.17134 Build 17134` and `Ubuntu 18.04.2 LTS`. Both individual contract file and truffle directory compilation was tested.

IMPORTANT: Prior to merging this pull request, macOS should be tested for the following cases:
- Individual contracts
- Truffle directory (immediate contracts + nodejs resources, ie: open-zeppelin)