### PR TITLE
Fixed two issues: Address prefixes in filename query etherscan, solc argument list can have blanks

### DIFF
--- a/crytic_compile/platform/etherscan.py
+++ b/crytic_compile/platform/etherscan.py
@@ -106,7 +106,7 @@ def compile(crytic_compile, target, **kwargs):
 def is_etherscan(target):
     if target.startswith(tuple(supported_network)):
         target = target[target.find(':') + 1:]
-    return re.match('0x[a-zA-Z0-9]{40}', target)
+    return re.match('\s*0x[a-zA-Z0-9]{40}\s*$', target)
 
 
 def convert_version(version):

--- a/crytic_compile/platform/etherscan.py
+++ b/crytic_compile/platform/etherscan.py
@@ -106,7 +106,7 @@ def compile(crytic_compile, target, **kwargs):
 def is_etherscan(target):
     if target.startswith(tuple(supported_network)):
         target = target[target.find(':') + 1:]
-    return re.match('\s*0x[a-zA-Z0-9]{40}\s*$', target)
+    return re.match('^\s*0x[a-zA-Z0-9]{40}\s*$', target)
 
 
 def convert_version(version):

--- a/crytic_compile/platform/solc.py
+++ b/crytic_compile/platform/solc.py
@@ -140,7 +140,7 @@ def _run_solc(crytic_compile, filename, solc, solc_disable_warnings, solc_argume
         # split() removes the delimiter, so we add it again
         solc_args = [('--' + x).split(' ', 1) for x in solc_args if x]
         # Flat the list of list
-        solc_args = [item for sublist in solc_args for item in sublist]
+        solc_args = [item for sublist in solc_args for item in sublist if item]
         cmd += solc_args
 
     additional_kwargs = {'cwd': working_dir} if working_dir else {}


### PR DESCRIPTION
This pull request aims to resolve #9 along with an additional issue.

Fixed:
- Any filename prefixed with an address would be caught by the etherscan query regex, and would incorrectly assume we are intending to analyze an etherscan contract.
- `solc` arguments could contain blank `''` items, which would cause some `solc` compilations to fail.

The second issue can be seen here:
```
>>> slither --print function-id 0x00be721be5e52da3a7e3e3e1dd871bbc5e1c17fb

Compilation warnings/errors on crytic-export\REALotteryWheel.sol:
"""" is not found

ERROR:Slither:Invalid compilation
ERROR:Slither:Invalid solc compilation """" is not found
```