### PR TITLE
Fixed a bug where sources without contracts would cause an error

### DIFF
--- a/crytic_compile/platform/solc.py
+++ b/crytic_compile/platform/solc.py
@@ -32,23 +32,24 @@ def compile(crytic_compile, target, **kwargs):
                              solc_remaps=solc_remaps,
                              working_dir=solc_working_dir)
 
+    if "contracts" in targets_json:
+        for original_contract_name, info in targets_json["contracts"].items():
+            contract_name = extract_name(original_contract_name)
+            contract_filename = extract_filename(original_contract_name)
+            contract_filename = convert_filename(contract_filename, _relative_to_short, working_dir=solc_working_dir)
+            crytic_compile.contracts_names.add(contract_name)
+            crytic_compile.contracts_filenames[contract_name] = contract_filename
+            crytic_compile.abis[contract_name] = json.loads(info['abi'])
+            crytic_compile.bytecodes_init[contract_name] = info['bin']
+            crytic_compile.bytecodes_runtime[contract_name] = info['bin-runtime']
+            crytic_compile.srcmaps_init[contract_name] = info['srcmap'].split(';')
+            crytic_compile.srcmaps_runtime[contract_name] = info['srcmap-runtime'].split(';')
 
-    for original_contract_name, info in targets_json["contracts"].items():
-        contract_name = extract_name(original_contract_name)
-        contract_filename = extract_filename(original_contract_name)
-        contract_filename = convert_filename(contract_filename, _relative_to_short, working_dir=solc_working_dir)
-        crytic_compile.contracts_names.add(contract_name)
-        crytic_compile.contracts_filenames[contract_name] = contract_filename
-        crytic_compile.abis[contract_name] = json.loads(info['abi'])
-        crytic_compile.bytecodes_init[contract_name] = info['bin']
-        crytic_compile.bytecodes_runtime[contract_name] = info['bin-runtime']
-        crytic_compile.srcmaps_init[contract_name] = info['srcmap'].split(';')
-        crytic_compile.srcmaps_runtime[contract_name] = info['srcmap-runtime'].split(';')
-
-    for path, info in targets_json["sources"].items():
-        path = convert_filename(path, _relative_to_short, working_dir=solc_working_dir)
-        crytic_compile.filenames.add(path)
-        crytic_compile.asts[path.absolute] = info['AST']
+    if "sources" in targets_json:
+        for path, info in targets_json["sources"].items():
+            path = convert_filename(path, _relative_to_short, working_dir=solc_working_dir)
+            crytic_compile.filenames.add(path)
+            crytic_compile.asts[path.absolute] = info['AST']
 
 def is_solc(target):
     return os.path.isfile(target) and target.endswith('.sol')


### PR DESCRIPTION
This pull request aims to resolve a bug where crytic-compile would attempt to access the `contracts` field of the compilation output, causing an issue if a source without any contracts was compiled.

For example, a file with the following contents:
```
pragma solidity ^0.4.23;
```
would cause the following error:
```
ERROR:root:Error in .
ERROR:root:Traceback (most recent call last):
  File "c:\users\vyper\documents\github\slither\slither\__main__.py", line 562, in main_impl
    (results_tmp, number_contracts_tmp) = process(filename, args, detector_classes, printer_classes)
  File "c:\users\vyper\documents\github\slither\slither\__main__.py", line 50, in process
    **vars(args))
  File "c:\users\vyper\documents\github\slither\slither\slither.py", line 59, in __init__
    cryticCompile = CryticCompile(contract, **kwargs)
  File "c:\users\vyper\documents\github\crytic-compile\crytic_compile\crytic_compile.py", line 67, in __init__
    self._compile(target, **kwargs)
  File "c:\users\vyper\documents\github\crytic-compile\crytic_compile\crytic_compile.py", line 583, in _compile
    compile_solc(self, target, **kwargs)
  File "c:\users\vyper\documents\github\crytic-compile\crytic_compile\platform\solc.py", line 36, in compile
    for original_contract_name, info in targets_json["contracts"].items():
KeyError: 'contracts'
```