### PR TITLE
Unicode characters in etherscan contract fail to write to disk

### DIFF
--- a/crytic_compile/platform/etherscan.py
+++ b/crytic_compile/platform/etherscan.py
@@ -69,7 +69,7 @@ def compile(crytic_compile, target, **kwargs):
     if not os.path.exists(os.path.join('crytic-export', 'etherscan_contracts')):
         os.makedirs(os.path.join('crytic-export', 'etherscan_contracts'))
 
-    with open(filename, 'w') as f:
+    with open(filename, 'w', encoding='utf8') as f:
         f.write(source_code)
 
     compiler_version = re.findall('\d+\.\d+\.\d+', convert_version(result['CompilerVersion']))[0]


### PR DESCRIPTION
This pull request aims to fix an issue where unicode characters in an etherscan contract would fail to write to disk due to UTF-8 encoding not being set on the file I/O. 

Prior to this fix, the following command:
```
crytic-compile 0x5d0d76787d9d564061dd23f8209f804a3b8ad2f2
```
would result in the following error:
```
Traceback (most recent call last):
  File "C:\Python\Python37\Scripts\crytic-compile-script.py", line 11, in <module>
    load_entry_point('crytic-compile', 'console_scripts', 'crytic-compile')()
  File "c:\users\vyper\documents\github\crytic-compile\crytic_compile\__main__.py", line 77, in main
    cryticCompile = CryticCompile(**vars(args))
  File "c:\users\vyper\documents\github\crytic-compile\crytic_compile\crytic_compile.py", line 68, in __init__
    self._compile(target, **kwargs)
  File "c:\users\vyper\documents\github\crytic-compile\crytic_compile\crytic_compile.py", line 590, in _compile
    self._platform.compile(self, target, **kwargs)
  File "c:\users\vyper\documents\github\crytic-compile\crytic_compile\platform\etherscan.py", line 73, in compile
    f.write(source_code)
  File "C:\Python\Python37\lib\encodings\cp1252.py", line 19, in encode
    return codecs.charmap_encode(input,self.errors,encoding_table)[0]
UnicodeEncodeError: 'charmap' codec can't encode characters in position 3783-3794: character maps to <undefined>
```

