### PR TITLE
Archive exporting + glob patterns

### DIFF
--- a/crytic_compile/__init__.py
+++ b/crytic_compile/__init__.py
@@ -1,3 +1,4 @@
-from .crytic_compile import CryticCompile, is_supported
+from .crytic_compile import CryticCompile, is_supported, compile_all
 from .platform import InvalidCompilation
 from .cryticparser import cryticparser
+from .utils.zip import save_to_zip

--- a/crytic_compile/__main__.py
+++ b/crytic_compile/__main__.py
@@ -84,11 +84,7 @@ def parse_args():
 def main():
     args = parse_args()
     try:
-        # Attempt to perform glob expansion of target/filename
-        globbed_targets = glob.glob(args.target, recursive=True)
-
-        # Check if the target refers to a valid target already.
-        # If it does not, we assume it's a glob pattern.
+        # Compile all specified (possibly glob patterned) targets.
         compilations = CryticCompile.compile_all(**vars(args))
 
         # Perform relevant tasks for each compilation

--- a/crytic_compile/__main__.py
+++ b/crytic_compile/__main__.py
@@ -85,6 +85,7 @@ def main():
                 print(f'\tUsed: {filename.used}')
     except InvalidCompilation as e:
         logger.error(e)
+        sys.exit(-1)
 
 
 if __name__ == '__main__':

--- a/crytic_compile/__main__.py
+++ b/crytic_compile/__main__.py
@@ -32,10 +32,16 @@ def parse_args():
                         default=None)
 
     parser.add_argument('--export-dir',
-                        help='Export directory (default: crytic-export',
+                        help='Export directory (default: crytic-export)',
                         action='store',
                         dest='export_dir',
                         default='crytic-export')
+
+    parser.add_argument('--export-src',
+                        help='Include source code when exporting (default: false)',
+                        action='store_true',
+                        dest='export_src',
+                        default=False)
 
     parser.add_argument('--print-filenames',
                         help='Print all the filenames',

--- a/crytic_compile/crytic_compile.py
+++ b/crytic_compile/crytic_compile.py
@@ -257,14 +257,12 @@ class CryticCompile:
         init = self._init_bytecodes.get(name, None)
         return self._update_bytecode_with_libraries(init, libraries)
 
-
     # endregion
     ###################################################################################
     ###################################################################################
     # region Source mapping
     ###################################################################################
     ###################################################################################
-
 
     @property
     def srcmaps_init(self):
@@ -290,6 +288,9 @@ class CryticCompile:
                     with open(filename.absolute, encoding='utf8', newline='') as source_file:
                         self._src_content[filename.absolute] = source_file.read()
         return self._src_content
+
+    def src_content_for_file(self, filename_absolute):
+        return self.src_content.get(filename_absolute, None)
 
     # endregion
     ###################################################################################
@@ -544,7 +545,10 @@ class CryticCompile:
 
             archive.set_dependency_status(filename.absolute, contract['is_dependency'])
 
-        # Set all our filenames
+            # Set all source code
+            self._src_content[filename.absolute] = compiled_archive['source_content'][filename.absolute]
+
+        # Set our filenames
         self._filenames = set(self._contracts_filenames.values())
 
         self._working_dir = compilation['working_dir']
@@ -572,7 +576,7 @@ class CryticCompile:
         # Determine if we are exporting a singular archive, or exporting each individually.
         if export_format == 'archive':
             # Create our source file dictionary
-            results['source_files'] = {}
+            results['source_content'] = {}
 
             # If we are to export source..
             for compilation in compilations:
@@ -581,7 +585,7 @@ class CryticCompile:
 
                 # Next set all source content
                 for filename_absolute, source_content in compilation.src_content.items():
-                    results['source_files'][filename_absolute] = source_content
+                    results['source_content'][filename_absolute] = source_content
 
             # If we have an export directory specified, we output the JSON to a file.
             export_dir = kwargs.get('export_dir', None)

--- a/crytic_compile/platform/archive.py
+++ b/crytic_compile/platform/archive.py
@@ -1,0 +1,27 @@
+import os
+import logging
+
+from .types import Type
+logger = logging.getLogger("CryticCompile")
+
+DEPENDENCIES = {}
+
+
+def compile(crytic_compile, target, **kwargs):
+    crytic_compile.type = Type.ARCHIVE
+
+
+def is_solc(target):
+    return os.path.isfile(target) and target.endswith('.sol')
+
+
+def is_dependency(_path):
+    return DEPENDENCIES[_path]
+
+
+def set_dependency_status(_path, status):
+    DEPENDENCIES[_path] = status
+
+
+def _relative_to_short(relative):
+    return relative

--- a/crytic_compile/platform/archive.py
+++ b/crytic_compile/platform/archive.py
@@ -1,27 +1,51 @@
 import os
-import logging
+import json
+from pathlib import Path
+from . import standard
 
-from .types import Type
-logger = logging.getLogger("CryticCompile")
-
-DEPENDENCIES = {}
-
+def is_archive(target):
+    return Path(target).parts[-1].endswith("_export_archive.json")
 
 def compile(crytic_compile, target, **kwargs):
-    crytic_compile.type = Type.ARCHIVE
+    if os.path.isfile(target):
+        with open(target, encoding='utf8') as f:
+            loaded_json = json.load(f)
+    else:
+        loaded_json = json.loads(target)
+    standard.load_from_compile(crytic_compile, loaded_json)
 
+    crytic_compile._src_content = loaded_json['source_content']
 
-def is_solc(target):
-    return os.path.isfile(target) and target.endswith('.sol')
+def generate_archive_export(crytic_compile):
+    output = standard.generate_standard_export(crytic_compile)
+    output['source_content'] = crytic_compile.src_content
 
+    target = crytic_compile.target
+    target = "contracts" if os.path.isdir(target) else Path(target).parts[-1]
+    target = f"{target}_export_archive.json"
+
+    return output, target
+
+def export(crytic_compile, **kwargs):
+    # Obtain objects to represent each contract
+
+    output, target = generate_archive_export(crytic_compile)
+
+    export_dir = kwargs.get('export_dir', "crytic-compile")
+    if export_dir:
+        if not os.path.exists(export_dir):
+            os.makedirs(export_dir)
+
+        path = os.path.join(export_dir, target)
+        with open(path, 'w', encoding='utf8') as f:
+            json.dump(output, f)
+
+        return path
+    return None
 
 def is_dependency(_path):
-    return DEPENDENCIES[_path]
-
-
-def set_dependency_status(_path, status):
-    DEPENDENCIES[_path] = status
-
+    # handled by crytic_compile_dependencies
+    return False
 
 def _relative_to_short(relative):
     return relative

--- a/crytic_compile/platform/solc.py
+++ b/crytic_compile/platform/solc.py
@@ -104,36 +104,42 @@ def is_dependency(_path):
     return False
 
 def export(crytic_compile, **kwargs):
-    export_dir = kwargs.get('export_dir', 'crytic-export')
-    if not os.path.exists(export_dir):
-        os.makedirs(export_dir)
-    path = os.path.join(export_dir, "combined_solc.json")
+    # Obtain objects to represent each contract
+    contracts = dict()
+    for contract_name in crytic_compile.contracts_names:
+        abi = str(crytic_compile.abi(contract_name))
+        abi = abi.replace('\'', '\"')
+        abi = abi.replace('True', 'true')
+        abi = abi.replace('False', 'false')
+        abi = abi.replace(' ', '')
+        exported_name = combine_filename_name(crytic_compile.contracts_filenames[contract_name].absolute, contract_name)
+        contracts[exported_name] = {
+            'srcmap': ';'.join(crytic_compile.srcmap_init(contract_name)),
+            'srcmap-runtime': ';'.join(crytic_compile.srcmap_runtime(contract_name)),
+            'abi': abi,
+            'bin': crytic_compile.bytecode_init(contract_name),
+            'bin-runtime': crytic_compile.bytecode_runtime(contract_name)
+        }
 
-    with open(path, 'w', encoding='utf8') as f:
-        contracts = dict()
-        for contract_name in crytic_compile.contracts_names:
-            abi = str(crytic_compile.abi(contract_name))
-            abi = abi.replace('\'', '\"')
-            abi = abi.replace('True', 'true')
-            abi = abi.replace('False', 'false')
-            abi = abi.replace(' ', '')
-            exported_name = combine_filename_name(crytic_compile.contracts_filenames[contract_name].absolute, contract_name)
-            contracts[exported_name] = {
-                'srcmap': ';'.join(crytic_compile.srcmap_init(contract_name)),
-                'srcmap-runtime': ';'.join(crytic_compile.srcmap_runtime(contract_name)),
-                'abi': abi,
-                'bin': crytic_compile.bytecode_init(contract_name),
-                'bin-runtime': crytic_compile.bytecode_runtime(contract_name)
-            }
+    # Create additional informational objects.
+    sources = {filename: {"AST": ast} for (filename, ast) in crytic_compile.asts.items()}
+    source_list = [x.absolute for x in crytic_compile.filenames]
 
-        sources = {filename : {"AST": ast} for (filename, ast) in crytic_compile.asts.items()}
-        sourceList = [x.absolute for x in crytic_compile.filenames]
+    # Create our root object to contain the contracts and other information.
+    output = {'sources': sources,
+              'sourceList': source_list,
+              'contracts': contracts}
 
-        output = {'sources' : sources,
-                  'sourceList' : sourceList,
-                  'contracts': contracts}
+    # If we have an export directory specified, we output the JSON.
+    export_dir = kwargs.get('export_dir', None)
+    if export_dir:
+        if not os.path.exists(export_dir):
+            os.makedirs(export_dir)
+        path = os.path.join(export_dir, "combined_solc.json")
 
-        json.dump(output, f)
+        with open(path, 'w', encoding='utf8') as f:
+            json.dump(output, f)
+    return output
 
 def get_version(solc):
     cmd  = [solc, "--version"]

--- a/crytic_compile/platform/solc.py
+++ b/crytic_compile/platform/solc.py
@@ -139,7 +139,8 @@ def export(crytic_compile, **kwargs):
 
         with open(path, 'w', encoding='utf8') as f:
             json.dump(output, f)
-    return output
+        return path
+    return None
 
 def get_version(solc):
     cmd  = [solc, "--version"]

--- a/crytic_compile/platform/standard.py
+++ b/crytic_compile/platform/standard.py
@@ -1,0 +1,108 @@
+# Standard crytic-compile export
+import os
+import json
+from pathlib import Path
+
+from crytic_compile.compiler.compiler import CompilerVersion
+from crytic_compile.utils.naming import Filename
+
+def is_standard(target):
+    return Path(target).parts[-1].endswith("_export.json")
+
+def generate_standard_export(crytic_compile):
+    contracts = dict()
+    for contract_name in crytic_compile.contracts_names:
+        filename = crytic_compile.filename_of_contract(contract_name)
+        contracts[contract_name] = {
+            'abi': crytic_compile.abi(contract_name),
+            'bin': crytic_compile.bytecode_init(contract_name),
+            'bin-runtime': crytic_compile.bytecode_runtime(contract_name),
+            'srcmap': ";".join(crytic_compile.srcmap_init(contract_name)),
+            'srcmap-runtime': ";".join(crytic_compile.srcmap_runtime(contract_name)),
+            'filenames': {
+                'absolute': filename.absolute,
+                'used': filename.used,
+                'short': filename.short,
+                'relative': filename.used
+            },
+            'is_dependency': crytic_compile._platform.is_dependency(filename.absolute)
+        }
+
+    # Create our root object to contain the contracts and other information.
+    output = {
+        'asts': crytic_compile._asts,
+        'contracts': contracts,
+        'compiler': {
+            'compiler': crytic_compile._compiler_version.compiler,
+            'version': crytic_compile._compiler_version.version,
+            'optimized': crytic_compile._compiler_version.optimized,
+        },
+        'working_dir': str(crytic_compile._working_dir),
+        'type': int(crytic_compile._type)
+    }
+    return output
+
+def export(crytic_compile, **kwargs):
+    # Obtain objects to represent each contract
+
+    output = generate_standard_export(crytic_compile)
+
+    export_dir = kwargs.get('export_dir', "crytic-compile")
+    if export_dir:
+        if not os.path.exists(export_dir):
+            os.makedirs(export_dir)
+
+        target = crytic_compile.target
+        target = "contracts" if os.path.isdir(target) else Path(target).parts[-1]
+
+        path = os.path.join(export_dir, f"{target}_archive.json")
+        with open(path, 'w', encoding='utf8') as f:
+            json.dump(output, f)
+
+        return path
+    return None
+
+def compile(crytic_compile, target, **kwargs):
+    with open(target, encoding='utf8') as f:
+        loaded_json = json.load(f)
+    load_from_compile(crytic_compile, loaded_json)
+
+def load_from_compile(crytic_compile, loaded_json):
+    crytic_compile._asts = loaded_json['asts']
+    crytic_compile._compiler_version = CompilerVersion(compiler=loaded_json['compiler']['compiler'],
+                                             version=loaded_json['compiler']['version'],
+                                             optimized=loaded_json['compiler']['optimized'])
+    for contract_name, contract in loaded_json['contracts'].items():
+        crytic_compile._contracts_name.add(contract_name)
+        filename = Filename(absolute=contract['filenames']['absolute'],
+                            relative=contract['filenames']['used'],
+                            short=contract['filenames']['short'],
+                            used=contract['filenames']['relative'])
+        crytic_compile._contracts_filenames[contract_name] = filename
+
+        crytic_compile._abis[contract_name] = contract['abi']
+        crytic_compile._init_bytecodes[contract_name] = contract['bin']
+        crytic_compile._runtime_bytecodes[contract_name] = contract['bin-runtime']
+        crytic_compile._srcmaps[contract_name] = contract['srcmap'].split(';')
+        crytic_compile._srcmaps_runtime[contract_name] = contract['srcmap-runtime'].split(';')
+
+        if contract['is_dependency']:
+            crytic_compile._is_dependencies.add(filename.absolute)
+            crytic_compile._is_dependencies.add(filename.relative)
+            crytic_compile._is_dependencies.add(filename.short)
+            crytic_compile._is_dependencies.add(filename.used)
+
+
+    # Set our filenames
+    crytic_compile._filenames = set(crytic_compile._contracts_filenames.values())
+
+    crytic_compile._working_dir = loaded_json['working_dir']
+    crytic_compile._type = loaded_json['type']
+
+
+def is_dependency(filename):
+    # handled by crytic_compile_dependencies
+    return False
+
+def _relative_to_short(relative):
+    return relative

--- a/crytic_compile/platform/truffle.py
+++ b/crytic_compile/platform/truffle.py
@@ -111,22 +111,31 @@ def compile(crytic_compile, target, **kwargs):
 
 
 def export(crytic_compile, **kwargs):
-    export_dir = kwargs.get('export_dir', 'crytic-export')
-    if not os.path.exists(export_dir):
+    # Get our export directory, if it's set, we create the path.
+    export_dir = kwargs.get('export_dir', None)
+    if export_dir and not os.path.exists(export_dir):
         os.makedirs(export_dir)
 
+    # Loop for each contract filename.
+    results = []
     for contract_name in crytic_compile.contracts_names:
+        # Create the informational object to output for this contract
         filename = crytic_compile.contracts_filenames[contract_name]
-        with open(os.path.join(export_dir, contract_name  + '.json'), 'w', encoding='utf8') as f:
-            output = {
-                "contractName": contract_name ,
-                "abi": crytic_compile.abi(contract_name),
-                "bytecode": "0x" + crytic_compile.bytecode_init(contract_name),
-                "deployedBytecode": "0x" + crytic_compile.bytecode_runtime(contract_name),
-                "ast": crytic_compile.ast(filename)
-            }
-            json.dump(output, f)
+        output = {
+            "contractName": contract_name,
+            "abi": crytic_compile.abi(contract_name),
+            "bytecode": "0x" + crytic_compile.bytecode_init(contract_name),
+            "deployedBytecode": "0x" + crytic_compile.bytecode_runtime(contract_name),
+            "ast": crytic_compile.ast(filename)
+        }
+        results.append(results)
 
+        # If we have an export directory, export it.
+        if export_dir:
+            with open(os.path.join(export_dir, contract_name + '.json'), 'w', encoding='utf8') as f:
+                json.dump(output, f)
+
+    return results
 
 def is_truffle(target):
     return (os.path.isfile(os.path.join(target, 'truffle.js')) or

--- a/crytic_compile/platform/truffle.py
+++ b/crytic_compile/platform/truffle.py
@@ -132,10 +132,12 @@ def export(crytic_compile, **kwargs):
 
         # If we have an export directory, export it.
         if export_dir:
-            with open(os.path.join(export_dir, contract_name + '.json'), 'w', encoding='utf8') as f:
+            path = os.path.join(export_dir, contract_name + '.json')
+            with open(path, 'w', encoding='utf8') as f:
                 json.dump(output, f)
+            return path
 
-    return results
+    return None
 
 def is_truffle(target):
     return (os.path.isfile(os.path.join(target, 'truffle.js')) or

--- a/crytic_compile/platform/types.py
+++ b/crytic_compile/platform/types.py
@@ -1,12 +1,14 @@
-from enum import Enum
+from enum import IntEnum
 
-class Type(Enum):
+
+class Type(IntEnum):
     SOLC = 1
     TRUFFLE = 2
     EMBARK = 3
     DAPP = 4
     ETHERLIME = 5
     ETHERSCAN = 6
+    ARCHIVE = 7
 
     def __str__(self):
         if self == Type.SOLC:
@@ -21,4 +23,6 @@ class Type(Enum):
             return 'Etherlime'
         if self == Type.ETHERSCAN:
             return 'Etherscan'
+        if self == Type.ARCHIVE:
+            return 'Archive'
         raise ValueError

--- a/crytic_compile/platform/types.py
+++ b/crytic_compile/platform/types.py
@@ -8,7 +8,8 @@ class Type(IntEnum):
     DAPP = 4
     ETHERLIME = 5
     ETHERSCAN = 6
-    ARCHIVE = 7
+    STANDARD = 7
+    ARCHIVE = 8
 
     def __str__(self):
         if self == Type.SOLC:
@@ -23,6 +24,8 @@ class Type(IntEnum):
             return 'Etherlime'
         if self == Type.ETHERSCAN:
             return 'Etherscan'
+        if self == Type.STANDARD:
+            return 'Standard'
         if self == Type.ARCHIVE:
             return 'Archive'
         raise ValueError

--- a/crytic_compile/utils/zip.py
+++ b/crytic_compile/utils/zip.py
@@ -1,0 +1,18 @@
+import json
+from zipfile import ZipFile
+from crytic_compile.platform.archive import generate_archive_export
+
+def load_from_zip(target):
+    from crytic_compile.crytic_compile import CryticCompile
+    compilations = []
+    with ZipFile(target, 'r') as f:
+        for project in f.namelist():
+            compilations.append(CryticCompile(f.read(project), compile_force_framework="archive"))
+
+    return compilations
+
+def save_to_zip(crytic_compiles, zipfile):
+    with ZipFile(zipfile, 'w') as f:
+        for crytic_compile in crytic_compiles:
+            output, target_name = generate_archive_export(crytic_compile)
+            f.writestr(target_name, json.dumps(output))

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ setup(
     description='Util to facilitate smart contracts compilation.',
     url='https://github.com/crytic/crytic-compile',
     author='Trail of Bits',
-    version='0.1.1',
+    version='0.1.2',
     packages=find_packages(),
     python_requires='>=3.6',
     install_requires=['pysha3>=1.0.2'],


### PR DESCRIPTION
This pull request aims to move glob patterns and other compilation-related tasks from slither into crytic-compile. Additionally, it aims to resolve #23 by adding support for a new type of export: `archive`. This export method exports all compilations (multiple in the case of glob pattern compilations, one for each file) into a single JSON archive with source code. This allows a user to export an entire solidity code base with all dependencies into a single file. A potential usage of this feature is to export a compiled archive of an entire truffle/embark project, which another user can analyze in slither without truffle/embark installed.

The archive export method is simply a singular JSON file with multiple underlying "standard export formats" (the default crytic-compile format) and source content included. As such, some additional fields such as `is_dependency` was added to the standard export format.