### PR TITLE
Add libraries to the standard JSON

### DIFF
--- a/crytic_compile/__main__.py
+++ b/crytic_compile/__main__.py
@@ -30,9 +30,15 @@ def parse_args():
                         default='crytic.config.json')
 
     parser.add_argument('--export-format',
-                        help='Export json with non crytic-compile format (default None. Accepted: solc, truffle)',
+                        help='Export json with non crytic-compile format (default None. Accepted: standard, solc, truffle)',
                         action='store',
                         dest='export_format',
+                        default=None)
+
+    parser.add_argument('--export-formats',
+                        help='Comma-separated list of export format, defaults to None',
+                        action='store',
+                        dest='export_formats',
                         default=None)
 
     parser.add_argument('--export-dir',
@@ -101,9 +107,18 @@ def main():
                         print(f'\tShort: {filename.short}')
                         print(f'\tUsed: {filename.used}')
                         printed_filenames.add(unique_id)
+            if args.export_format:
+                compilation.export(**vars(args))
+
+            if args.export_formats:
+                for format in args.export_formats.split(','):
+                    args.export_format = format
+                    compilation.export(**vars(args))
 
         if args.export_to_zip:
             save_to_zip(compilations, args.export_to_zip)
+
+
 
     except InvalidCompilation as e:
         logger.error(e)

--- a/crytic_compile/platform/standard.py
+++ b/crytic_compile/platform/standard.py
@@ -26,7 +26,7 @@ def generate_standard_export(crytic_compile):
                 'short': filename.short,
                 'relative': filename.used
             },
-            'libraries': librairies if librairies else dict(),
+            'libraries': dict(librairies) if librairies else dict(),
             'is_dependency': crytic_compile._platform.is_dependency(filename.absolute)
         }
 

--- a/crytic_compile/platform/standard.py
+++ b/crytic_compile/platform/standard.py
@@ -13,6 +13,7 @@ def generate_standard_export(crytic_compile):
     contracts = dict()
     for contract_name in crytic_compile.contracts_names:
         filename = crytic_compile.filename_of_contract(contract_name)
+        librairies = crytic_compile.libraries_names_and_patterns(contract_name)
         contracts[contract_name] = {
             'abi': crytic_compile.abi(contract_name),
             'bin': crytic_compile.bytecode_init(contract_name),
@@ -25,6 +26,7 @@ def generate_standard_export(crytic_compile):
                 'short': filename.short,
                 'relative': filename.used
             },
+            'libraries': librairies if librairies else dict(),
             'is_dependency': crytic_compile._platform.is_dependency(filename.absolute)
         }
 
@@ -55,7 +57,7 @@ def export(crytic_compile, **kwargs):
         target = crytic_compile.target
         target = "contracts" if os.path.isdir(target) else Path(target).parts[-1]
 
-        path = os.path.join(export_dir, f"{target}_archive.json")
+        path = os.path.join(export_dir, f"{target}.json")
         with open(path, 'w', encoding='utf8') as f:
             json.dump(output, f)
 
@@ -85,6 +87,7 @@ def load_from_compile(crytic_compile, loaded_json):
         crytic_compile._runtime_bytecodes[contract_name] = contract['bin-runtime']
         crytic_compile._srcmaps[contract_name] = contract['srcmap'].split(';')
         crytic_compile._srcmaps_runtime[contract_name] = contract['srcmap-runtime'].split(';')
+        crytic_compile._libraries[contract_name] = contract['libraries']
 
         if contract['is_dependency']:
             crytic_compile._is_dependencies.add(filename.absolute)


### PR DESCRIPTION
This PR adds the libraries info to the standard json, which becomes:

``` json
{
    "asts": [],
    "contracts": {
        "contract_name": {
            "abi": [],
            "bin": "..",
            "bin-runtime": "..",
            "srcmap": "..",
            "srcmap-runtime": "..",
            "filenames": {
                "absolute": "..",
                "relative": "..",
                "short": "..",
                "used": "..",
            },
            "librairies": {
                 "lib_name": "pattern"
            } 
        }
    },
    "compiler": {
        "compiler": "solc",
        "version": "x.x.x",
        "optimized": false
    },
    "working_dir": ".."
}
```

For example, on the truffle metacoin contract, this is added:
`"libraries": {"ConvertLib": "__ConvertLib____________________________"}`
