### PR TITLE
[WIP] Added solc json input as a new platform

### DIFF
--- a/crytic_compile/crytic_compile.py
+++ b/crytic_compile/crytic_compile.py
@@ -8,7 +8,7 @@ import subprocess
 import sha3
 from pathlib import Path
 
-from .platform import solc, truffle, embark, dapp, etherlime, etherscan, archive, standard, vyper
+from .platform import solc, solc_standard_json, truffle, embark, dapp, etherlime, etherscan, archive, standard, vyper
 from .utils.zip import load_from_zip
 
 logger = logging.getLogger("CryticCompile")
@@ -28,6 +28,7 @@ def is_supported(target):
     return any(f(target) for f in supported) or target.endswith('.zip')
 
 PLATFORMS = {'solc': solc,
+             'solc_standard_json': solc_standard_json,
              'truffle': truffle,
              'embark': embark,
              'dapp': dapp,

--- a/crytic_compile/crytic_compile.py
+++ b/crytic_compile/crytic_compile.py
@@ -47,6 +47,8 @@ def compile_all(target, **kwargs):
     :param kwargs: The remainder of the arguments passed through to all compilation steps.
     :return: Returns a list of CryticCompile instances for all compilations which occurred.
     """
+    use_solc_standard_json = kwargs.get('solc_standard_json', False)
+
     # Attempt to perform glob expansion of target/filename
     globbed_targets = glob.glob(target, recursive=True)
 
@@ -66,9 +68,17 @@ def compile_all(target, **kwargs):
             if not filenames:
                 filenames = globbed_targets
 
-        # We compile each file and add it to our compilations.
-        for filename in filenames:
-            compilations.append(CryticCompile(filename, **kwargs))
+        # Determine if we're using --standard-solc option to aggregate many files into a single compilation.
+        if use_solc_standard_json:
+            # If we're using standard solc, then we generated our input to create a single compilation with all files
+            standard_json = solc_standard_json.SolcStandardJson()
+            for filename in filenames:
+                standard_json.add_source_file(filename)
+            compilations.append(CryticCompile(standard_json, **kwargs))
+        else:
+            # We compile each file and add it to our compilations.
+            for filename in filenames:
+                compilations.append(CryticCompile(filename, **kwargs))
     else:
         raise ValueError(f"Unresolved target: {str(target)}")
 
@@ -80,7 +90,7 @@ class CryticCompile:
     def __init__(self, target, **kwargs):
         '''
             Args:
-                target (str)
+                target (str|SolcStandardJson)
             Keyword Args:
                 See https://github.com/crytic/crytic-compile/wiki/Configuration
         '''
@@ -652,7 +662,9 @@ class CryticCompile:
         if compile_force_framework and compile_force_framework in PLATFORMS:
             self._platform = PLATFORMS[compile_force_framework]
         else:
-            if not truffle_ignore and truffle.is_truffle(target):
+            if isinstance(target, solc_standard_json.SolcStandardJson):
+                self._platform = solc_standard_json
+            elif not truffle_ignore and truffle.is_truffle(target):
                 self._platform = truffle
             elif not embark_ignore and embark.is_embark(target):
                 self._platform = embark

--- a/crytic_compile/cryticparser/cryticparser.py
+++ b/crytic_compile/cryticparser/cryticparser.py
@@ -61,6 +61,11 @@ def init_solc(parser):
                             action='store',
                             default=defaults_flag_in_config['solc_solcs_bin'])
 
+    group_solc.add_argument('--solc-standard-json',
+                            help='Compile all specified targets in a single compilation using solc standard json',
+                            action='store_true',
+                            default=defaults_flag_in_config['solc_standard_json'])
+
 def init_truffle(parser):
     group_truffle = parser.add_argument_group('Truffle options')
     group_truffle.add_argument('--truffle-ignore-compile',

--- a/crytic_compile/cryticparser/defaults.py
+++ b/crytic_compile/cryticparser/defaults.py
@@ -10,6 +10,7 @@ defaults_flag_in_config = {
     'solc_working_dir': None,
     'solc_solcs_select': None,
     'solc_solcs_bin': None,
+    'solc_standard_json': False,
     'truffle_version': None,
     'truffle_ignore_compile': False,
     'truffle_build_directory': 'build/contracts',

--- a/crytic_compile/platform/solc_standard_json.py
+++ b/crytic_compile/platform/solc_standard_json.py
@@ -8,11 +8,68 @@ from .types import Type
 from ..utils.naming import extract_filename, extract_name, combine_filename_name, convert_filename
 from .exceptions import InvalidCompilation
 from ..compiler.compiler import CompilerVersion
-from .solc import export as export_solc, is_dependency as is_dependency_solc, get_version, _is_optimized, _relative_to_short
+from .solc import export as export_solc, is_dependency as is_dependency_solc, get_version, _is_optimized, \
+    _relative_to_short
 
 
 class SolcStandardJson:
-    pass
+    def __init__(self, target=None):
+        """
+        Initializes an object which represents solc standard json
+        :param target: A string path to a standard json
+        """
+        if target is None:
+            self._json = {}
+        elif isinstance(target, str):
+            if os.path.isfile(target):
+                with open(target, mode='r', encoding='utf-8') as target_file:
+                    self._json = json.load(target_file)
+            else:
+                self._json = json.loads(target)
+        elif isinstance(target, dict):
+            self._json = target
+        elif isinstance(target, SolcStandardJson):
+            self._json = target._json
+        else:
+            raise ValueError(f"Invalid target for solc standard json input.")
+
+        # Set some default values if they are not provided
+        if 'language' not in self._json:
+            self._json['language'] = "Solidity"
+        if 'sources' not in self._json:
+            self._json['sources'] = {}
+        if 'settings' not in self._json:
+            self._json['settings'] = {}
+
+        if 'remappings' not in self._json['settings']:
+            self._json['settings']['remappings'] = []
+        if 'optimizer' not in self._json['settings']:
+            self._json['settings']['optimizer'] = { "enabled": False}
+        if 'outputSelection' not in self._json['settings']:
+            self._json['settings']['outputSelection'] = {
+                "*": {
+                    "*": [
+                        "abi", "metadata", "evm.bytecode", "evm.deployedBytecode"
+                    ],
+                    "": [
+                        "ast"
+                    ],
+                }
+            }
+
+    def add_source_file(self, file_path):
+        # Append our remappings
+        self._json['sources'][file_path] = {
+            "urls": [file_path]
+        }
+
+    def add_remapping(self, remapping):
+        # Append our remappings
+        self._json['settings']['remappings'].append(remapping)
+
+    def to_dict(self):
+        # Patch in our desired output types
+        return self._json
 
 
 logger = logging.getLogger("CryticCompile")
@@ -35,18 +92,19 @@ def compile(crytic_compile, target, **kwargs):
     else:
         skip_filename = False
 
-    # If it's a string, decode it as JSON
-    if isinstance(target, str):
-        if os.path.isfile(target):
-            with open(target, mode='r', encoding='utf-8') as target_file:
-                target = json.load(target_file)
-        else:
-            target = json.loads(target)
+    # Initialize our solc input
+    target = SolcStandardJson(target)
 
-    # TODO: Patch in arguments to solc here.
+    # Add all remappings
+    if solc_remaps:
+        if isinstance(solc_remaps, str):
+            solc_remaps = solc_remaps.split(' ')
+        for solc_remap in solc_remaps:
+            target.add_remapping(solc_remap)
 
     # Invoke solc
-    targets_json = _run_solc_standard_json(crytic_compile, target, solc)
+    targets_json = _run_solc_standard_json(crytic_compile, target.to_dict(), solc,
+                                           solc_disable_warnings=solc_disable_warnings)
 
     if "contracts" in targets_json:
         for file_path, file_contracts in targets_json["contracts"].items():
@@ -62,9 +120,9 @@ def compile(crytic_compile, target, **kwargs):
                 crytic_compile.contracts_filenames[contract_name] = contract_filename
                 crytic_compile.abis[contract_name] = info['abi']
                 crytic_compile.bytecodes_init[contract_name] = info['evm']['bytecode']['object']
-                crytic_compile.bytecodes_runtime[contract_name] = ""#info['bin-runtime'] TODO!
+                crytic_compile.bytecodes_runtime[contract_name] = info['evm']['deployedBytecode']['object']
                 crytic_compile.srcmaps_init[contract_name] = info['evm']['bytecode']['sourceMap'].split(';')
-                crytic_compile.srcmaps_runtime[contract_name] = []#info['srcmap-runtime'].split(';') TODO!
+                crytic_compile.srcmaps_runtime[contract_name] = info['evm']['deployedBytecode']['sourceMap'].split(';')
 
     if "sources" in targets_json:
         for path, info in targets_json["sources"].items():
@@ -88,22 +146,22 @@ def export(crytic_compile, **kwargs):
     return export_solc(crytic_compile, **vars(kwargs))
 
 
-def _run_solc_standard_json(crytic_compile, target, solc, working_dir=None):
+def _run_solc_standard_json(crytic_compile, solc_input, solc, solc_disable_warnings=False, working_dir=None):
     """
     Note: Ensure that crytic_compile.compiler_version is set prior calling _run_solc
     :param crytic_compile:
-    :param target:
+    :param solc_input:
     :param solc:
     :param solc_disable_warnings:
-    :param solc_arguments:
-    :param solc_remaps:
-    :param env:
     :param working_dir:
     :return:
     """
     cmd = [solc, '--standard-json', '--allow-paths', '.']
-    process = subprocess.Popen(cmd, stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-    stdout, stderr = process.communicate(json.dumps(target).encode('utf-8'))
+    additional_kwargs = {'cwd': working_dir} if working_dir else {}
+
+    process = subprocess.Popen(cmd, stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+                               **additional_kwargs)
+    stdout, stderr = process.communicate(json.dumps(solc_input).encode('utf-8'))
     stdout, stderr = stdout.decode(), stderr.decode()  # convert bytestrings to unicode strings
 
     try:
@@ -117,10 +175,15 @@ def _run_solc_standard_json(crytic_compile, target, solc, working_dir=None):
             for solc_error in solc_errors:
                 if solc_error['severity'] != 'warning':
                     solc_error_occurred = True
+                elif solc_disable_warnings:
+                    continue
                 solc_exception_str += f"{solc_error.get('type', 'UnknownExceptionType')}: " \
                                       f"{solc_error.get('formattedMessage', 'N/A')}\n"
+
             if solc_error_occurred:
                 raise InvalidCompilation(solc_exception_str)
+            elif solc_exception_str:
+                logger.warning(solc_exception_str)
 
         return solc_json_output
     except json.decoder.JSONDecodeError:

--- a/crytic_compile/platform/solc_standard_json.py
+++ b/crytic_compile/platform/solc_standard_json.py
@@ -1,0 +1,127 @@
+import os
+import json
+import logging
+import subprocess
+import re
+
+from .types import Type
+from ..utils.naming import extract_filename, extract_name, combine_filename_name, convert_filename
+from .exceptions import InvalidCompilation
+from ..compiler.compiler import CompilerVersion
+from .solc import export as export_solc, is_dependency as is_dependency_solc, get_version, _is_optimized, _relative_to_short
+
+
+class SolcStandardJson:
+    pass
+
+
+logger = logging.getLogger("CryticCompile")
+
+
+def compile(crytic_compile, target, **kwargs):
+    crytic_compile.type = Type.SOLC_STANDARD_JSON
+    solc = kwargs.get('solc', 'solc')
+    solc_disable_warnings = kwargs.get('solc_disable_warnings', False)
+    solc_arguments = kwargs.get('solc_args', '')
+    solc_remaps = kwargs.get('solc_remaps', None)
+    solc_working_dir = kwargs.get('solc_working_dir', None)
+
+    crytic_compile.compiler_version = CompilerVersion(compiler="solc",
+                                                      version=get_version(solc),
+                                                      optimized=_is_optimized(solc_arguments))
+
+    if crytic_compile.compiler_version.version in [f'0.4.{x}' for x in range(0, 10)]:
+        skip_filename = True
+    else:
+        skip_filename = False
+
+    # If it's a string, decode it as JSON
+    if isinstance(target, str):
+        if os.path.isfile(target):
+            with open(target, mode='r', encoding='utf-8') as target_file:
+                target = json.load(target_file)
+        else:
+            target = json.loads(target)
+
+    # TODO: Patch in arguments to solc here.
+
+    # Invoke solc
+    targets_json = _run_solc_standard_json(crytic_compile, target, solc)
+
+    if "contracts" in targets_json:
+        for file_path, file_contracts in targets_json["contracts"].items():
+            for contract_name, info in file_contracts.items():
+                # for solc < 0.4.10 we cant retrieve the filename from the ast
+                if skip_filename:
+                    contract_filename = convert_filename(target, _relative_to_short,
+                                                         working_dir=solc_working_dir)
+                else:
+                    contract_filename = convert_filename(file_path, _relative_to_short,
+                                                         working_dir=solc_working_dir)
+                crytic_compile.contracts_names.add(contract_name)
+                crytic_compile.contracts_filenames[contract_name] = contract_filename
+                crytic_compile.abis[contract_name] = info['abi']
+                crytic_compile.bytecodes_init[contract_name] = info['evm']['bytecode']['object']
+                crytic_compile.bytecodes_runtime[contract_name] = ""#info['bin-runtime'] TODO!
+                crytic_compile.srcmaps_init[contract_name] = info['evm']['bytecode']['sourceMap'].split(';')
+                crytic_compile.srcmaps_runtime[contract_name] = []#info['srcmap-runtime'].split(';') TODO!
+
+    if "sources" in targets_json:
+        for path, info in targets_json["sources"].items():
+            if skip_filename:
+                path = convert_filename(target, _relative_to_short, working_dir=solc_working_dir)
+            else:
+                path = convert_filename(path, _relative_to_short, working_dir=solc_working_dir)
+            crytic_compile.filenames.add(path)
+            crytic_compile.asts[path.absolute] = info['ast']
+
+
+def is_solc(target):
+    return os.path.isfile(target) and target.endswith('.sol')
+
+
+def is_dependency(_path):
+    return is_dependency_solc(_path)
+
+
+def export(crytic_compile, **kwargs):
+    return export_solc(crytic_compile, **vars(kwargs))
+
+
+def _run_solc_standard_json(crytic_compile, target, solc, working_dir=None):
+    """
+    Note: Ensure that crytic_compile.compiler_version is set prior calling _run_solc
+    :param crytic_compile:
+    :param target:
+    :param solc:
+    :param solc_disable_warnings:
+    :param solc_arguments:
+    :param solc_remaps:
+    :param env:
+    :param working_dir:
+    :return:
+    """
+    cmd = [solc, '--standard-json', '--allow-paths', '.']
+    process = subprocess.Popen(cmd, stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    stdout, stderr = process.communicate(json.dumps(target).encode('utf-8'))
+    stdout, stderr = stdout.decode(), stderr.decode()  # convert bytestrings to unicode strings
+
+    try:
+        solc_json_output = json.loads(stdout)
+
+        # Check for errors and raise them if any exist.
+        solc_errors = solc_json_output.get('errors', [])
+        if solc_errors:
+            solc_error_occurred = False
+            solc_exception_str = ""
+            for solc_error in solc_errors:
+                if solc_error['severity'] != 'warning':
+                    solc_error_occurred = True
+                solc_exception_str += f"{solc_error.get('type', 'UnknownExceptionType')}: " \
+                                      f"{solc_error.get('formattedMessage', 'N/A')}\n"
+            if solc_error_occurred:
+                raise InvalidCompilation(solc_exception_str)
+
+        return solc_json_output
+    except json.decoder.JSONDecodeError:
+        raise InvalidCompilation(f'Invalid solc compilation {stderr}')

--- a/crytic_compile/platform/types.py
+++ b/crytic_compile/platform/types.py
@@ -11,10 +11,13 @@ class Type(IntEnum):
     STANDARD = 7
     ARCHIVE = 8
     VYPER = 9
+    SOLC_STANDARD_JSON = 10
 
     def __str__(self):
         if self == Type.SOLC:
             return 'solc'
+        if self == Type.SOLC_STANDARD_JSON:
+            return 'solc_standard_json'
         if self == Type.TRUFFLE:
             return 'Truffle'
         if self == Type.EMBARK:


### PR DESCRIPTION
This PR adds solc json input as a new platform. Namely, this PR allows crytic-compile to handle the json format provided to solc via `STDIN` when the `--standard-json` argument is specified.

This platform can be accessed by:
- Forcing the compile framework to `solc_standard_json` and specifying a json config as a target
- Passing a `SolcStandardJson` (json wrapper) object to `CryticCompile`.

Additionally, this PR adds a `--solc-standard-json` argument, which specifies that globbed targets should be wrapped in a `SolcStandardJson` object, and the new solc compilation platform should be used. (This allows globbed targets to be compiled in a single compilation, instead of compiled individually for each target).

TODOs:
- [ ] verify we do not need to permit more paths for the solc argument `--allow-paths`.
- [ ] verify remappings work as intended in `SolcStandardJson`.