### PR TITLE
Prevent crash if there are non-contract artifacts in the json directory

### DIFF
--- a/crytic_compile/platform/dapp.py
+++ b/crytic_compile/platform/dapp.py
@@ -27,6 +27,10 @@ def compile(crytic_compile, target, **kwargs):
     for file in files:
         with open(file, encoding='utf8') as f:
             targets_json = json.load(f)
+
+        if not "contracts" in targets_json:
+            continue
+
         for original_contract_name, info in targets_json["contracts"].items():
             contract_name = extract_name(original_contract_name)
             contract_filename = extract_filename(original_contract_name)

--- a/crytic_compile/platform/etherlime.py
+++ b/crytic_compile/platform/etherlime.py
@@ -54,6 +54,9 @@ def compile(crytic_compile, target, **kwargs):
                     if "version" in target_loaded["compiler"]:
                         version = re.findall('\d+\.\d+\.\d+', target_loaded["compiler"]["version"])[0]
 
+            if not 'ast' in target_loaded:
+                continue
+
             filename =target_loaded['ast']['absolutePath']
             filename = convert_filename(filename, _relative_to_short)
             crytic_compile.asts[filename.absolute] = target_loaded['ast']

--- a/crytic_compile/platform/truffle.py
+++ b/crytic_compile/platform/truffle.py
@@ -90,6 +90,8 @@ def compile(crytic_compile, target, **kwargs):
                     except json.decoder.JSONDecodeError:
                         pass
 
+            if not 'ast' in target_loaded:
+                continue
 
             filename = target_loaded['ast']['absolutePath']
             filename = convert_filename(filename, _relative_to_short, working_dir=target)


### PR DESCRIPTION
Some builds create json files that are not regular artifacts. 
This PR allows crytic-compile to skip these files instead of crashing