### PR TITLE
Add naive parsing of the truffle config file to retrieve solc version

### DIFF
--- a/crytic_compile/cryticparser/cryticparser.py
+++ b/crytic_compile/cryticparser/cryticparser.py
@@ -23,6 +23,7 @@ def init(parser):
     init_embark(parser)
     init_dapp(parser)
     init_etherlime(parser)
+    init_npx(parser)
 
 def init_solc(parser):
     group_solc = parser.add_argument_group('Solc options')
@@ -121,3 +122,11 @@ def init_etherlime(parser):
                                  dest='etherlime_compile_arguments',
                                  default=defaults_flag_in_config['etherlime_compile_arguments'])
 
+
+def init_npx(parser):
+    group_npx = parser.add_argument_group('NPX options')
+    group_npx.add_argument('--npx-disable',
+                           help='Do not use npx',
+                           action='store_true',
+                           dest='npx_disable',
+                           default=defaults_flag_in_config['npx_disable'])

--- a/crytic_compile/cryticparser/defaults.py
+++ b/crytic_compile/cryticparser/defaults.py
@@ -19,4 +19,5 @@ defaults_flag_in_config = {
     'dapp_ignore_compile': False,
     'etherlime_ignore_compile': False,
     'etherlime_compile_arguments': None,
+    'npx_disable': False
 }

--- a/crytic_compile/platform/truffle.py
+++ b/crytic_compile/platform/truffle.py
@@ -26,6 +26,8 @@ def compile(crytic_compile, target, **kwargs):
 
     if platform.system() == 'Windows':
         base_cmd = ["truffle.cmd"]
+    elif kwargs.get('npx_disable', False):
+        base_cmd = ["truffle"]
     else:
         base_cmd = ["npx", "truffle"]
         if truffle_version:

--- a/crytic_compile/platform/truffle.py
+++ b/crytic_compile/platform/truffle.py
@@ -56,7 +56,6 @@ def compile(crytic_compile, target, **kwargs):
     version_from_config =_get_version_from_config(target)
     if version_from_config:
         version, compiler = version_from_config
-        print(version)
     else:
         version, compiler = _get_version(base_cmd, cwd=target)
 

--- a/crytic_compile/platform/truffle.py
+++ b/crytic_compile/platform/truffle.py
@@ -53,7 +53,12 @@ def compile(crytic_compile, target, **kwargs):
                         truffle_version = 'truffle@{}'.format(version)
                         base_cmd = ['npx', truffle_version]
 
-    version, compiler = _get_version(base_cmd, cwd=target)
+    version_from_config =_get_version_from_config(target)
+    if version_from_config:
+        version, compiler = version_from_config
+        print(version)
+    else:
+        version, compiler = _get_version(base_cmd, cwd=target)
 
     if not truffle_ignore_compile:
         cmd = base_cmd + ['compile', '--all']
@@ -147,6 +152,31 @@ def is_truffle(target):
 
 def is_dependency(path):
     return 'node_modules' in Path(path).parts
+
+
+def _get_version_from_config(target):
+    '''
+    Naive check on the truffleconfig file to get the version
+    :param target:
+    :return: (version, compiler) | None
+    '''
+    config = Path(target, 'truffle-config.js')
+    if not config.exists():
+        config = Path(target, 'truffle.js')
+        if not config.exists():
+            return None
+    with open(config) as config_f:
+        config_buffer = config_f.read()
+
+    # The config is a javascript file
+    # Use a naive regex to match the solc version
+    match = re.search(r'solc: {[ ]*\n[ ]*version: "([0-9\.]*)', config_buffer)
+    if match:
+        if match.groups():
+            version = match.groups()[0]
+            return version, "solc-js"
+    return None
+
 
 def _get_version(truffle_call, cwd):
     cmd = truffle_call + ["version"]


### PR DESCRIPTION
Calling `truffle version` to retrieve the solc version is expansive.  This PR tries to solve this by using a regex on the truffle config file to get the solc version.

This PR is based on #37 