### PR TITLE
Use cache to speed up dapp installation on CI

### DIFF
--- a/scripts/travis_test_dapp.sh
+++ b/scripts/travis_test_dapp.sh
@@ -7,6 +7,8 @@ cd /tmp/dapp
 
 curl https://nixos.org/nix/install | sh
 . "$HOME/.nix-profile/etc/profile.d/nix.sh"
+nix-env -iA nixpkgs.cachix
+cachix use dapp
 git clone --recursive https://github.com/dapphub/dapptools $HOME/.dapp/dapptools
 nix-env -f $HOME/.dapp/dapptools -iA dapp seth solc hevm ethsign
 


### PR DESCRIPTION
I've added the cache setup to the long running CI script. The packages were build from source however there is a cache available for `dapptools` on cachix (a cache for Nix packages). This should significantly speed up the installation. It works on my local machine, unfortunately I didn't get a chance to test it on Travis. In response to https://github.com/crytic/crytic-compile/issues/39.