### PR TITLE
Etherscan: Allow for bytecode-only contracts

### DIFF
--- a/crytic_compile/crytic_compile.py
+++ b/crytic_compile/crytic_compile.py
@@ -148,6 +148,8 @@ class CryticCompile:
         self._type = None
         self._platform = None
 
+        self._bytecode_only = False
+
         # compiler.compiler
         self._compiler_version = None
 
@@ -162,6 +164,7 @@ class CryticCompile:
             target = (target, 0)
 
         self._compile(target, **kwargs)
+
 
     @property
     def target(self):
@@ -408,6 +411,18 @@ class CryticCompile:
     @compiler_version.setter
     def compiler_version(self, c):
         self._compiler_version = c
+
+    @property
+    def bytecode_only(self):
+        '''
+        Return true if only the bytecode was retrieved
+        :return:
+        '''
+        return self._bytecode_only
+
+    @bytecode_only.setter
+    def bytecode_only(self, b):
+        self._bytecode_only = b
 
     # endregion
     ###################################################################################

--- a/crytic_compile/cryticparser/cryticparser.py
+++ b/crytic_compile/cryticparser/cryticparser.py
@@ -30,6 +30,7 @@ def init(parser):
     init_embark(parser)
     init_dapp(parser)
     init_etherlime(parser)
+    init_etherscan(parser)
     init_waffle(parser)
     init_npx(parser)
 
@@ -196,6 +197,23 @@ def init_etherlime(parser):
         default=defaults_flag_in_config["etherlime_compile_arguments"],
     )
 
+def init_etherscan(parser):
+    group_etherscan = parser.add_argument_group("Etherscan options")
+    group_etherscan.add_argument(
+        "--etherscan-only-source-code",
+        help="Only compile if the source code is available.",
+        action="store_true",
+        dest="etherscan_only_source_code",
+        default=defaults_flag_in_config["etherscan_only_source_code"],
+    )
+
+    group_etherscan.add_argument(
+        "--etherscan-only-bytecode",
+        help="Only looks for bytecode.",
+        action="store_true",
+        dest="etherscan_only_bytecode",
+        default=defaults_flag_in_config["etherscan_only_bytecode"],
+    )
 
 def init_npx(parser):
     group_npx = parser.add_argument_group("NPX options")

--- a/crytic_compile/cryticparser/defaults.py
+++ b/crytic_compile/cryticparser/defaults.py
@@ -20,6 +20,8 @@ defaults_flag_in_config = {
     "dapp_ignore_compile": False,
     "etherlime_ignore_compile": False,
     "etherlime_compile_arguments": None,
+    "etherscan_only_source_code": False,
+    "etherscan_only_bytecode": False,
     "waffle_ignore_compile": False,
     "waffle_config_file": None,
     "npx_disable": False,

--- a/crytic_compile/platform/etherscan.py
+++ b/crytic_compile/platform/etherscan.py
@@ -7,13 +7,17 @@ import re
 from .types import Type
 from .exceptions import InvalidCompilation
 from .solc import _run_solc
-from ..utils.naming import extract_filename, extract_name, convert_filename
+from ..utils.naming import extract_filename, extract_name, convert_filename, Filename
 from ..compiler.compiler import CompilerVersion
 
 logger = logging.getLogger("CryticCompile")
 
 ethercan_base = (
     "https://api%s.etherscan.io/api?module=contract&action=getsourcecode&address=%s"
+)
+
+ethercan_base_bytecode = (
+    "%s%shttps://etherscan.io/address/%s#code"
 )
 
 supported_network = {
@@ -26,6 +30,38 @@ supported_network = {
 }
 
 
+def _handle_bytecode(crytic_compile, target, result):
+    # There is no direct API to get the bytecode from etherscan
+    # The page changes from time to time, we use for now a simple parsing, it will not be robust
+    begin = '''Search Algorithm">\nSimilar Contracts</button>\n<div id="dividcode">\n<pre class=\'wordwrap\' style=\'height: 15pc;\'>0x'''
+    result = result.decode('utf8')
+    # Removing everything before the begin string
+    result = result[result.find(begin)+len(begin):]
+    bytecode = result[:result.find('<')]
+
+    contract_name = f'Contract_{target}'
+
+    contract_filename = Filename(
+        absolute='',
+        relative='',
+        short='',
+        used='',
+    )
+
+    crytic_compile.contracts_names.add(contract_name)
+    crytic_compile.contracts_filenames[contract_name] = contract_filename
+    crytic_compile.abis[contract_name] = {}
+    crytic_compile.bytecodes_init[contract_name] = bytecode
+    crytic_compile.bytecodes_runtime[contract_name] = ''
+    crytic_compile.srcmaps_init[contract_name] = []
+    crytic_compile.srcmaps_runtime[contract_name] = []
+
+    crytic_compile.compiler_version = CompilerVersion(
+        compiler="unknown", version='', optimized=None
+    )
+
+    crytic_compile.bytecode_only = True
+
 def compile(crytic_compile, target, **kwargs):
     crytic_compile.type = Type.ETHERSCAN
 
@@ -35,31 +71,55 @@ def compile(crytic_compile, target, **kwargs):
         prefix = supported_network[target[: target.find(":") + 1]]
         addr = target[target.find(":") + 1 :]
         etherscan_url = ethercan_base % (prefix, addr)
+        if prefix != "":
+            etherscan_bytecode_url = ethercan_base_bytecode % (prefix, ".", addr)
+        else:
+            etherscan_bytecode_url = ethercan_base_bytecode % (prefix, "", addr)
     else:
         etherscan_url = ethercan_base % ("", target)
+        etherscan_bytecode_url = ethercan_base_bytecode % ("", "", target)
         addr = target
         prefix = None
 
-    with urllib.request.urlopen(etherscan_url) as response:
-        html = response.read()
+    only_source = kwargs.get('etherscan_only_source_code', False)
+    only_bytecode = kwargs.get('etherscan_only_bytecode', False)
 
-    info = json.loads(html)
+    source_code = ''
+    result = None
+    contract_name = None
 
-    if not "message" in info:
-        logger.error("Incorrect etherscan request")
-        raise InvalidCompilation("Incorrect etherscan request " + etherscan_url)
+    if not only_bytecode:
+        with urllib.request.urlopen(etherscan_url) as response:
+            html = response.read()
 
-    if info["message"] != "OK":
-        logger.error("Contract has no public source code")
-        raise InvalidCompilation("Contract has no public source code: " + etherscan_url)
+        info = json.loads(html)
 
-    if not "result" in info:
-        logger.error("Contract has no public source code")
-        raise InvalidCompilation("Contract has no public source code: " + etherscan_url)
+        if not "message" in info:
+            logger.error("Incorrect etherscan request")
+            raise InvalidCompilation("Incorrect etherscan request " + etherscan_url)
 
-    result = info["result"][0]
-    source_code = result["SourceCode"]
-    contract_name = result["ContractName"]
+        if info["message"] != "OK":
+            logger.error("Contract has no public source code")
+            raise InvalidCompilation("Contract has no public source code: " + etherscan_url)
+
+        if not "result" in info:
+            logger.error("Contract has no public source code")
+            raise InvalidCompilation("Contract has no public source code: " + etherscan_url)
+
+        result = info["result"][0]
+        source_code = result["SourceCode"]
+        contract_name = result["ContractName"]
+
+    if source_code == '' and not only_source:
+        logger.info('Source code not available, try to fetch the bytecode only')
+
+        req = urllib.request.Request(etherscan_bytecode_url, headers={"User-Agent": "Mozilla/5.0"})
+        with urllib.request.urlopen(req) as response:
+            html = response.read()
+
+        _handle_bytecode(crytic_compile, target, html)
+        return
+
 
     if prefix:
         filename = os.path.join(

--- a/crytic_compile/platform/etherscan.py
+++ b/crytic_compile/platform/etherscan.py
@@ -17,16 +17,17 @@ ethercan_base = (
 )
 
 ethercan_base_bytecode = (
-    "%s%shttps://etherscan.io/address/%s#code"
+    "https://%setherscan.io/address/%s#code"
 )
 
 supported_network = {
-    "mainet:": "",
-    "ropsten:": "-ropsten",
-    "kovan:": "-kovan",
-    "rinkeby:": "-rinkeby",
-    "goerli:": "-goerli",
-    "tobalaba:": "-tobalaba",
+    # Key, (prefix_base, perfix_bytecode)
+    "mainet:":   ("",          ""),
+    "ropsten:":  ("-ropsten",  "ropsten."),
+    "kovan:":    ("-kovan",    "kovan."),
+    "rinkeby:":  ("-rinkeby",  "rinkeby."),
+    "goerli:":   ("-goerli",   "goerli."),
+    "tobalaba:": ("-tobalaba", "tobalaba."),
 }
 
 
@@ -68,16 +69,15 @@ def compile(crytic_compile, target, **kwargs):
     solc = kwargs.get("solc", "solc")
 
     if target.startswith(tuple(supported_network)):
-        prefix = supported_network[target[: target.find(":") + 1]]
+        prefix = supported_network[target[: target.find(":") + 1]][0]
+        prefix_bytecode = supported_network[target[: target.find(":") + 1]][1]
         addr = target[target.find(":") + 1 :]
         etherscan_url = ethercan_base % (prefix, addr)
-        if prefix != "":
-            etherscan_bytecode_url = ethercan_base_bytecode % (prefix, ".", addr)
-        else:
-            etherscan_bytecode_url = ethercan_base_bytecode % (prefix, "", addr)
+        etherscan_bytecode_url = ethercan_base_bytecode % (prefix_bytecode, addr)
+
     else:
         etherscan_url = ethercan_base % ("", target)
-        etherscan_bytecode_url = ethercan_base_bytecode % ("", "", target)
+        etherscan_bytecode_url = ethercan_base_bytecode % ("", target)
         addr = target
         prefix = None
 


### PR DESCRIPTION
The parsing is not robust: etherscan does not provide a direct API, we have to parse the html page instead of using the json api.