### PR TITLE
Update Etherscan platform

### DIFF
--- a/crytic_compile/platform/etherscan.py
+++ b/crytic_compile/platform/etherscan.py
@@ -110,7 +110,7 @@ def compile(crytic_compile: "CryticCompile", target: str, **kwargs: str):
             LOGGER.error("Incorrect etherscan request")
             raise InvalidCompilation("Incorrect etherscan request " + etherscan_url)
 
-        if info["message"] != "OK":
+        if not info["message"].startswith("OK"):
             LOGGER.error("Contract has no public source code")
             raise InvalidCompilation("Contract has no public source code: " + etherscan_url)
 


### PR DESCRIPTION
A few days ago Etherscan changed its return message to `"OK-Missing/Invalid API Key, rate limit of 1/sec applied"` if no API key is provided.