### PR TITLE
Etherlime: use deleteCompiledFiles

### DIFF
--- a/crytic_compile/platform/etherlime.py
+++ b/crytic_compile/platform/etherlime.py
@@ -53,7 +53,7 @@ class Etherlime(AbstractPlatform):
         compile_arguments = kwargs.get("etherlime_compile_arguments", None)
 
         if not etherlime_ignore_compile:
-            cmd = ["etherlime", "compile", self._target]
+            cmd = ["etherlime", "compile", self._target, "deleteCompiledFiles=true"]
 
             if not kwargs.get("npx_disable", False):
                 cmd = ["npx"] + cmd


### PR DESCRIPTION
Fix #16

This flag is present since almost 1 year, so I did not add support for etherlime < 1.1.3, as I don't expect that anyone is using an older version.