### PR TITLE
Fix brownie test

### DIFF
--- a/scripts/travis_test_brownie.sh
+++ b/scripts/travis_test_brownie.sh
@@ -4,7 +4,7 @@ pip install eth-brownie
 brownie bake token
 cd token
 
-crytic-compile . 
+crytic-compile . --compile-force-framework Brownie
 
 if [ $? -ne 0 ]
 then


### PR DESCRIPTION
Since https://github.com/iamdefinitelyahuman/brownie/pull/408 the config file is optional. As a result the regression test needs `--compile-force-framework Brownie`