### PR TITLE
Truffle: add --truffle-overwrite-config and --truffle-overwrite-version

### DIFF
--- a/crytic_compile/cryticparser/cryticparser.py
+++ b/crytic_compile/cryticparser/cryticparser.py
@@ -156,6 +156,21 @@ def _init_truffle(parser):
         action="store",
         default=DEFAULTS_FLAG_IN_CONFIG["truffle_version"],
     )
+
+    group_truffle.add_argument(
+        "--truffle-overwrite-config",
+        help="Use a simplified version of truffle-config.js for compilation",
+        action="store_true",
+        default=DEFAULTS_FLAG_IN_CONFIG["truffle_overwrite_config"],
+    )
+
+    group_truffle.add_argument(
+        "--truffle-overwrite-version",
+        help="Overwrite solc version in truffle-config.js (only if --truffle-overwrite-config)",
+        action="store",
+        default=DEFAULTS_FLAG_IN_CONFIG["truffle_overwrite_version"],
+    )
+
     return group_truffle
 
 

--- a/crytic_compile/cryticparser/defaults.py
+++ b/crytic_compile/cryticparser/defaults.py
@@ -17,6 +17,8 @@ DEFAULTS_FLAG_IN_CONFIG = {
     "truffle_version": None,
     "truffle_ignore_compile": False,
     "truffle_build_directory": "build/contracts",
+    "truffle_overwrite_config": False,
+    "truffle_overwrite_version": None,
     "embark_ignore_compile": False,
     "embark_overwrite_config": False,
     "brownie_ignore_compile": False,


### PR DESCRIPTION
Use case:
- `truffle-config.js` has many dependencies and additional steps that are not needed for the compilation (ex: require to setup `.env`  file)
- On a codebase without compilation framework, this will allow to quickly move it to a truffle project. You can to move all the contracts to `./contracts`  and run ` --truffle-overwrite-config --truffle-overwrite-version X` 