### PR TITLE
Fix natspec parsing in Buidler

### DIFF
--- a/crytic_compile/platform/buidler.py
+++ b/crytic_compile/platform/buidler.py
@@ -120,8 +120,8 @@ class Buidler(AbstractPlatform):
                         crytic_compile.bytecodes_runtime[contract_name] = info["evm"]["deployedBytecode"]["object"]
                         crytic_compile.srcmaps_init[contract_name] = info["evm"]["bytecode"]["sourceMap"].split(";")
                         crytic_compile.srcmaps_runtime[contract_name] = info["evm"]["bytecode"]["sourceMap"].split(";")
-                        userdoc = json.loads(info.get("userdoc", "{}"))
-                        devdoc = json.loads(info.get("devdoc", "{}"))
+                        userdoc = info.get("userdoc", {})
+                        devdoc = info.get("devdoc", {})
                         natspec = Natspec(userdoc, devdoc)
                         crytic_compile.natspec[contract_name] = natspec
 


### PR DESCRIPTION
The JSON gets previously decoded so these are just Python objects at this point. I didn't look to deep into this, the Buidler setup I was using was pretty vanilla (nothing special passed to solc).

My Crytic + Buidler setup was failing with:

```
$ slither . --print contract-summary --json contract-summary.json --ignore-compile
Error invoking slither command "['slither', '.', '--print', 'contract-summary', '--json', 'contract-summary.json', '--ignore-compile']":
Traceback (most recent call last):
  File "/home/worker/.virtualenvs/crytic-venv/lib/python3.6/site-packages/slither_analyzer-0.6.12-py3.6.egg/slither/__main__.py", line 606, in main_impl
    printer_classes)
  File "/home/worker/.virtualenvs/crytic-venv/lib/python3.6/site-packages/slither_analyzer-0.6.12-py3.6.egg/slither/__main__.py", line 61, in process_all
    compilations = compile_all(target, **vars(args))
  File "/home/worker/.virtualenvs/crytic-venv/lib/python3.6/site-packages/crytic_compile-0.1.8-py3.6.egg/crytic_compile/crytic_compile.py", line 1013, in compile_all
    compilations.append(CryticCompile(target, **kwargs))
  File "/home/worker/.virtualenvs/crytic-venv/lib/python3.6/site-packages/crytic_compile-0.1.8-py3.6.egg/crytic_compile/crytic_compile.py", line 119, in __init__
    self._compile(**kwargs)
  File "/home/worker/.virtualenvs/crytic-venv/lib/python3.6/site-packages/crytic_compile-0.1.8-py3.6.egg/crytic_compile/crytic_compile.py", line 924, in _compile
    self._platform.compile(self, **kwargs)
  File "/home/worker/.virtualenvs/crytic-venv/lib/python3.6/site-packages/crytic_compile-0.1.8-py3.6.egg/crytic_compile/platform/buidler.py", line 123, in compile
    userdoc = json.loads(info.get("userdoc", "{}"))
  File "/usr/lib/python3.6/json/__init__.py", line 348, in loads
    'not {!r}'.format(s.__class__.__name__))
TypeError: the JSON object must be str, bytes or bytearray, not 'dict'
```