### PR TITLE
Add fix for the buidler directory bug

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,3 @@ Run `crytic-compile --help` for more options.
 ### As a library
 
 See the [library documentation](https://github.com/crytic/crytic-compile/wiki/Library-Documentation).
-
-### For users of Buidler
-
-As explained in this [thread](https://github.com/crytic/crytic-compile/issues/116), Buidler has a bug activated when the "paths.root" field is set in `buidler.config.ts`. The "root" of a Buidler project is implicit to where the configuration file is found, so you usually don't need to set this field. For troubleshooting, you should ask the Buidler team directly.

--- a/crytic_compile/cryticparser/cryticparser.py
+++ b/crytic_compile/cryticparser/cryticparser.py
@@ -301,4 +301,12 @@ def _init_buidler(parser):
         default=DEFAULTS_FLAG_IN_CONFIG["buidler_cache_directory"],
     )
 
+    group_buidler.add_argument(
+        "--buidler-skip-directory-name-fix",
+        help="Disable directory name fix (see https://github.com/crytic/crytic-compile/issues/116)",
+        action="store_true",
+        dest="buidler_skip_directory_name_fix",
+        default=DEFAULTS_FLAG_IN_CONFIG["buidler_skip_directory_name_fix"],
+    )
+
     return group_buidler

--- a/crytic_compile/cryticparser/defaults.py
+++ b/crytic_compile/cryticparser/defaults.py
@@ -35,4 +35,5 @@ DEFAULTS_FLAG_IN_CONFIG = {
     "ignore_compile": False,
     "buidler_ignore_compile": False,
     "buidler_cache_directory": "cache",
+    "buidler_skip_directory_name_fix": False
 }

--- a/crytic_compile/cryticparser/defaults.py
+++ b/crytic_compile/cryticparser/defaults.py
@@ -35,5 +35,5 @@ DEFAULTS_FLAG_IN_CONFIG = {
     "ignore_compile": False,
     "buidler_ignore_compile": False,
     "buidler_cache_directory": "cache",
-    "buidler_skip_directory_name_fix": False
+    "buidler_skip_directory_name_fix": False,
 }

--- a/crytic_compile/platform/buidler.py
+++ b/crytic_compile/platform/buidler.py
@@ -50,6 +50,8 @@ class Buidler(AbstractPlatform):
             "ignore_compile", False
         )
         buidler_working_dir = kwargs.get("buidler_working_dir", None)
+        # See https://github.com/crytic/crytic-compile/issues/116
+        skip_directory_name_fix = kwargs.get("buidler_skip_directory_name_fix", False)
 
         base_cmd = ["buidler"]
         if not kwargs.get("npx_disable", False):
@@ -102,6 +104,9 @@ class Buidler(AbstractPlatform):
                     for original_contract_name, info in contracts_info.items():
                         contract_name = extract_name(original_contract_name)
 
+                        if original_filename.startswith('ontracts/') and not skip_directory_name_fix:
+                            original_filename = 'c' + original_filename
+
                         contract_filename = convert_filename(
                             original_filename,
                             relative_to_short,
@@ -132,6 +137,10 @@ class Buidler(AbstractPlatform):
 
             if "sources" in targets_json:
                 for path, info in targets_json["sources"].items():
+
+                    if path.startswith('ontracts/') and not skip_directory_name_fix:
+                        path = 'c' + path
+
                     if skip_filename:
                         path = convert_filename(
                             self._target,

--- a/crytic_compile/platform/buidler.py
+++ b/crytic_compile/platform/buidler.py
@@ -34,7 +34,7 @@ class Buidler(AbstractPlatform):
     PROJECT_URL = "https://github.com/nomiclabs/buidler"
     TYPE = Type.BUILDER
 
-    # pylint: disable=too-many-locals,too-many-statements
+    # pylint: disable=too-many-locals,too-many-statements,too-many-branches
     def compile(self, crytic_compile: "CryticCompile", **kwargs: str):
         """
         Compile the target
@@ -104,8 +104,11 @@ class Buidler(AbstractPlatform):
                     for original_contract_name, info in contracts_info.items():
                         contract_name = extract_name(original_contract_name)
 
-                        if original_filename.startswith('ontracts/') and not skip_directory_name_fix:
-                            original_filename = 'c' + original_filename
+                        if (
+                            original_filename.startswith("ontracts/")
+                            and not skip_directory_name_fix
+                        ):
+                            original_filename = "c" + original_filename
 
                         contract_filename = convert_filename(
                             original_filename,
@@ -138,8 +141,8 @@ class Buidler(AbstractPlatform):
             if "sources" in targets_json:
                 for path, info in targets_json["sources"].items():
 
-                    if path.startswith('ontracts/') and not skip_directory_name_fix:
-                        path = 'c' + path
+                    if path.startswith("ontracts/") and not skip_directory_name_fix:
+                        path = "c" + path
 
                     if skip_filename:
                         path = convert_filename(


### PR DESCRIPTION
Fix https://github.com/crytic/crytic-compile/issues/116

If the directory name starts with `ontracts/`, change the path to `contracts/`. This can be removed with the `--buidler-skip-directory-name-fix` flag