### PR TITLE
Add memoization for filename_lookup and cache for is_dependency

### DIFF
--- a/crytic_compile/crytic_compile.py
+++ b/crytic_compile/crytic_compile.py
@@ -93,6 +93,8 @@ class CryticCompile:
         self._filenames: Set[Filename] = set()
         # mapping from contract name to filename (naming.Filename)
         self._contracts_filenames: Dict[str, Filename] = {}
+        # mapping from absolute/relative/used to filename
+        self._filenames_lookup: Optional[Dict[str, Filename]] = None
 
         # Libraries used by the contract
         # contract_name -> (library, pattern)
@@ -235,14 +237,15 @@ class CryticCompile:
         :param filename: str
         :return: crytic_compile.naming.Filename
         """
-        d_file = {}
-        for file in self._filenames:
-            d_file[file.absolute] = file
-            d_file[file.relative] = file
-            d_file[file.used] = file
-        if filename not in d_file:
-            raise ValueError(f"{filename} does not exist in {d_file}")
-        return d_file[filename]
+        if self._filenames_lookup is None:
+            self._filenames_lookup = {}
+            for file in self._filenames:
+                self._filenames_lookup[file.absolute] = file
+                self._filenames_lookup[file.relative] = file
+                self._filenames_lookup[file.used] = file
+        if filename not in self._filenames_lookup:
+            raise ValueError(f"{filename} does not exist in {self._filenames_lookup}")
+        return self._filenames_lookup[filename]
 
     @property
     def dependencies(self) -> Set[str]:

--- a/crytic_compile/platform/abstract_platform.py
+++ b/crytic_compile/platform/abstract_platform.py
@@ -2,7 +2,8 @@
 Abstract Platform
 """
 import abc
-from typing import TYPE_CHECKING, List
+from pathlib import Path
+from typing import TYPE_CHECKING, List, Dict
 
 from crytic_compile.platform import Type
 from crytic_compile.utils.unit_tests import guess_tests
@@ -48,6 +49,7 @@ class AbstractPlatform(metaclass=abc.ABCMeta):
             )
 
         self._target: str = target
+        self._cached_dependencies: Dict[Path, bool] = dict()
 
     # region Properties.
     ###################################################################################

--- a/crytic_compile/platform/buidler.py
+++ b/crytic_compile/platform/buidler.py
@@ -180,7 +180,11 @@ class Buidler(AbstractPlatform):
         :param path:
         :return:
         """
-        return "node_modules" in Path(path).parts
+        if path in self._cached_dependencies:
+            return self._cached_dependencies[path]
+        ret = "node_modules" in Path(path).parts
+        self._cached_dependencies[path] = ret
+        return ret
 
     def _guessed_tests(self) -> List[str]:
         """

--- a/crytic_compile/platform/embark.py
+++ b/crytic_compile/platform/embark.py
@@ -171,7 +171,11 @@ class Embark(AbstractPlatform):
         :param path:
         :return:
         """
-        return "node_modules" in Path(path).parts
+        if path in self._cached_dependencies:
+            return self._cached_dependencies[path]
+        ret = "node_modules" in Path(path).parts
+        self._cached_dependencies[path] = ret
+        return ret
 
     def _guessed_tests(self) -> List[str]:
         """

--- a/crytic_compile/platform/etherlime.py
+++ b/crytic_compile/platform/etherlime.py
@@ -167,7 +167,11 @@ class Etherlime(AbstractPlatform):
         :param path:
         :return:
         """
-        return "node_modules" in Path(path).parts
+        if path in self._cached_dependencies:
+            return self._cached_dependencies[path]
+        ret = "node_modules" in Path(path).parts
+        self._cached_dependencies[path] = ret
+        return ret
 
     def _guessed_tests(self) -> List[str]:
         """

--- a/crytic_compile/platform/hardhat.py
+++ b/crytic_compile/platform/hardhat.py
@@ -168,7 +168,11 @@ class Hardhat(AbstractPlatform):
         :param path:
         :return:
         """
-        return "node_modules" in Path(path).parts
+        if path in self._cached_dependencies:
+            return self._cached_dependencies[path]
+        ret = "node_modules" in Path(path).parts
+        self._cached_dependencies[path] = ret
+        return ret
 
     def _guessed_tests(self) -> List[str]:
         """

--- a/crytic_compile/platform/truffle.py
+++ b/crytic_compile/platform/truffle.py
@@ -273,7 +273,11 @@ class Truffle(AbstractPlatform):
         :param path:
         :return:
         """
-        return "node_modules" in Path(path).parts
+        if path in self._cached_dependencies:
+            return self._cached_dependencies[path]
+        ret = "node_modules" in Path(path).parts
+        self._cached_dependencies[path] = ret
+        return ret
 
     # pylint: disable=no-self-use
     def _guessed_tests(self) -> List[str]:

--- a/crytic_compile/platform/waffle.py
+++ b/crytic_compile/platform/waffle.py
@@ -245,7 +245,11 @@ class Waffle(AbstractPlatform):
         :param path:
         :return:
         """
-        return "node_modules" in Path(path).parts
+        if path in self._cached_dependencies:
+            return self._cached_dependencies[path]
+        ret = "node_modules" in Path(path).parts
+        self._cached_dependencies[path] = ret
+        return ret
 
     def _guessed_tests(self) -> List[str]:
         """


### PR DESCRIPTION
Fix #128

On a codebase that has hundred of files, this optimization gives a 30% time reduction for Slither