### PR TITLE
Fix solc version detection for --solc-solcs-(select|bin) case

### DIFF
--- a/crytic_compile/platform/solc.py
+++ b/crytic_compile/platform/solc.py
@@ -104,10 +104,6 @@ class Solc(AbstractPlatform):
         solc_working_dir = kwargs.get("solc_working_dir", None)
         force_legacy_json = kwargs.get("solc_force_legacy_json", False)
 
-        crytic_compile.compiler_version = CompilerVersion(
-            compiler="solc", version=get_version(solc), optimized=is_optimized(solc_arguments)
-        )
-
         # From config file, solcs is a dict (version -> path)
         # From command line, solc is a list
         # The guessing of version only works from config file
@@ -235,16 +231,16 @@ class Solc(AbstractPlatform):
         return []
 
 
-def get_version(solc: str) -> str:
+def get_version(solc: str, env: Dict[str, str]) -> str:
     """
-    Get the compiler verison used
+    Get the compiler version used
 
     :param solc:
     :return:
     """
     cmd = [solc, "--version"]
     try:
-        process = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        process = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, env=env)
     except OSError as error:
         # pylint: disable=raise-missing-from
         raise InvalidCompilation(error)
@@ -300,6 +296,10 @@ def _run_solc(
 
     if not filename.endswith(".sol"):
         raise InvalidCompilation("Incorrect file format")
+
+    crytic_compile.compiler_version = CompilerVersion(
+        compiler="solc", version=get_version(solc, env), optimized=is_optimized(solc_arguments)
+    )
 
     compiler_version = crytic_compile.compiler_version
     assert compiler_version

--- a/crytic_compile/platform/solc_standard_json.py
+++ b/crytic_compile/platform/solc_standard_json.py
@@ -128,7 +128,7 @@ class SolcStandardJson(Solc):
         solc_working_dir = kwargs.get("solc_working_dir", None)
 
         crytic_compile.compiler_version = CompilerVersion(
-            compiler="solc", version=get_version(solc), optimized=is_optimized(solc_arguments)
+            compiler="solc", version=get_version(solc, None), optimized=is_optimized(solc_arguments)
         )
 
         skip_filename = crytic_compile.compiler_version.version in [

--- a/crytic_compile/platform/truffle.py
+++ b/crytic_compile/platform/truffle.py
@@ -336,7 +336,7 @@ def _get_version(truffle_call: List[str], cwd: str) -> Tuple[str, str]:
     for line in stdout:
         if "Solidity" in line:
             if "native" in line:
-                return solc.get_version("solc"), "solc-native"
+                return solc.get_version("solc", None), "solc-native"
             version = re.findall(r"\d+\.\d+\.\d+", line)[0]
             compiler = re.findall(r"(solc[a-z\-]*)", line)
             if len(compiler) > 0:


### PR DESCRIPTION
Currently, the solc version is detected only once when starting, but
this may cause a mismatch between the detected version and the
compiler version that is then used. Move the version extraction
to the _run_solc(...) function to avoid this problem. Also add
support for passing an environment to get_version(...), this is
required when using compilers managed with solc-select.