### PR TITLE
Fix solc-guessing regular expression

### DIFF
--- a/crytic_compile/platform/solc.py
+++ b/crytic_compile/platform/solc.py
@@ -494,7 +494,7 @@ def _run_solcs_env(
     return targets_json
 
 
-PATTERN = re.compile(r"pragma solidity[\^|>=|<=]?[ ]+?(\d+\.\d+\.\d+)")
+PATTERN = re.compile(r"pragma solidity\s*(?:\^|>=|<=)?\s*(\d+\.\d+\.\d+)")
 
 
 def _guess_solc(target, solc_working_dir):


### PR DESCRIPTION
The current regular expression used to guess the solc version is
inadequate and does not handle many common scenarios. Rewrite it
to support other common use cases, such as "pragma solidity ^0.5.4".

Here are examples of how the previous and new regex react to
different "pragma solidity" strings:

case: pragma solidity 0.1.2
before: ['0.1.2']
after : ['0.1.2']

case: pragma solidity0.1.2
before: []
after : ['0.1.2']

case: pragma solidity^ 0.1.2
before: ['0.1.2']
after : ['0.1.2']

case: pragma solidity ^0.1.2
before: []
after : ['0.1.2']

case: pragma solidity^0.1.2
before: []
after : ['0.1.2']

case: pragma solidity>= 0.1.2
before: []
after : ['0.1.2']

case: pragma solidity >=0.1.2
before: []
after : ['0.1.2']

case: pragma solidity>=0.1.2
before: []
after : ['0.1.2']

case: pragma solidity<= 0.1.2
before: []
after : ['0.1.2']

case: pragma solidity <=0.1.2
before: []
after : ['0.1.2']

case: pragma solidity<=0.1.2
before: []
after : ['0.1.2']