### PR TITLE
Improve etherscan export dir

### DIFF
--- a/crytic_compile/__main__.py
+++ b/crytic_compile/__main__.py
@@ -65,7 +65,7 @@ see https://github.com/crytic/crytic-compile/wiki/Usage""",
         help="Export directory (default: crytic-export)",
         action="store",
         dest="export_dir",
-        default="crytic-export",
+        default=DEFAULTS_FLAG_IN_CONFIG["export_dir"],
     )
 
     parser.add_argument(

--- a/crytic_compile/cryticparser/defaults.py
+++ b/crytic_compile/cryticparser/defaults.py
@@ -2,7 +2,6 @@
 Default value for options
 """
 
-import os
 
 # Those are the flags shared by the command line and the config file
 DEFAULTS_FLAG_IN_CONFIG = {
@@ -32,7 +31,7 @@ DEFAULTS_FLAG_IN_CONFIG = {
     "etherscan_only_source_code": False,
     "etherscan_only_bytecode": False,
     "etherscan_api_key": None,
-    "etherscan_export_directory": os.path.join("crytic-export", "etherscan-contracts"),
+    "etherscan_export_directory": "etherscan-contracts",
     "waffle_ignore_compile": False,
     "waffle_config_file": None,
     "npx_disable": False,
@@ -43,4 +42,5 @@ DEFAULTS_FLAG_IN_CONFIG = {
     "hardhat_ignore_compile": False,
     "hardhat_cache_directory": "cache",
     "hardhat_artifacts_directory": "artifacts",
+    "export_dir": "crytic-export",
 }

--- a/crytic_compile/platform/etherscan.py
+++ b/crytic_compile/platform/etherscan.py
@@ -167,7 +167,10 @@ class Etherscan(AbstractPlatform):
 
         etherscan_api_key = kwargs.get("etherscan_api_key", None)
 
-        export_dir = kwargs.get("etherscan_export_dir")
+        export_dir = kwargs.get("export_dir", "crytic-export")
+        export_dir = os.path.join(
+            export_dir, kwargs.get("etherscan_export_dir", "etherscan-contracts")
+        )
 
         if etherscan_api_key:
             etherscan_url += f"&apikey={etherscan_api_key}"


### PR DESCRIPTION
- Etherscan can use the `--export-dir` flag
- `--etherscan-export-dir` only apply to the last part of the path

Fix consistency issue introduced in https://github.com/crytic/crytic-compile/pull/144