### PR TITLE
catch the Etherscan api rate limit error 

### DIFF
--- a/crytic_compile/platform/etherscan.py
+++ b/crytic_compile/platform/etherscan.py
@@ -186,6 +186,10 @@ class Etherscan(AbstractPlatform):
 
             info = json.loads(html)
 
+            if "result" in info and info["result"] == "Max rate limit reached":
+                LOGGER.error("Etherscan API rate limit exceeded")
+                raise InvalidCompilation("Etherscan api rate limit exceeded")
+
             if "message" not in info:
                 LOGGER.error("Incorrect etherscan request")
                 raise InvalidCompilation("Incorrect etherscan request " + etherscan_url)


### PR DESCRIPTION
The Etherscan API returns a specific response if the API rate limit is exceeded. This PR handles that response so that the error message says `Etherscan api rate limit exceeded` instead of the possibly incorrect `Contract has no public source code`.

See here for more info about the specific Etherscan Error responses: https://info.etherscan.com/api-return-errors/