### PR TITLE
Improve brownie support

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ setup(
     description="Util to facilitate smart contracts compilation.",
     url="https://github.com/crytic/crytic-compile",
     author="Trail of Bits",
-    version="0.1.12",
+    version="0.1.13",
     packages=find_packages(),
     python_requires=">=3.6",
     install_requires=["pysha3>=1.0.2"],


### PR DESCRIPTION
- Filter out vyper ast files
- Use a `rglob` to analyze dependencies

Tested on https://github.com/yearn/yearn-vaults
Fix #165
