### PR TITLE
Add support for multiple compilation units

### DIFF
--- a/crytic_compile/__init__.py
+++ b/crytic_compile/__init__.py
@@ -3,6 +3,7 @@ Init module
 """
 
 from .crytic_compile import CryticCompile, compile_all, is_supported
+from .compilation_unit import CompilationUnit
 from .cryticparser import cryticparser
 from .platform import InvalidCompilation
 from .utils.zip import save_to_zip

--- a/crytic_compile/__main__.py
+++ b/crytic_compile/__main__.py
@@ -153,7 +153,9 @@ class ShowPlatforms(argparse.Action):  # pylint: disable=too-few-public-methods
 def _print_filenames(compilation: "CryticCompile"):
     printed_filenames = set()
     for compilation_id, compilation_unit in compilation.compilation_units.items():
-        print(f"Compilation unit: {compilation_id} ({len(compilation_unit.contracts_names)} files, solc {compilation_unit.compiler_version.version})")
+        print(
+            f"Compilation unit: {compilation_id} ({len(compilation_unit.contracts_names)} files, solc {compilation_unit.compiler_version.version})"
+        )
         for contract in compilation_unit.contracts_names:
             filename = compilation_unit.filename_of_contract(contract)
             unique_id = f"{contract} - {filename} - {compilation_id}"

--- a/crytic_compile/__main__.py
+++ b/crytic_compile/__main__.py
@@ -153,7 +153,7 @@ class ShowPlatforms(argparse.Action):  # pylint: disable=too-few-public-methods
 def _print_filenames(compilation: "CryticCompile"):
     printed_filenames = set()
     for compilation_id, compilation_unit in compilation.compilation_units.items():
-        print(f"Compilation unit: {compilation_id} ({len(compilation_unit.contracts_names)} files)")
+        print(f"Compilation unit: {compilation_id} ({len(compilation_unit.contracts_names)} files, solc {compilation_unit.compiler_version.version})")
         for contract in compilation_unit.contracts_names:
             filename = compilation_unit.filename_of_contract(contract)
             unique_id = f"{contract} - {filename} - {compilation_id}"

--- a/crytic_compile/compilation_unit.py
+++ b/crytic_compile/compilation_unit.py
@@ -1,0 +1,657 @@
+import re
+from typing import TYPE_CHECKING, Dict, List, Optional, Set, Tuple, Union
+
+import sha3
+
+from crytic_compile.utils.naming import Filename
+from crytic_compile.utils.natspec import Natspec
+from crytic_compile.compiler.compiler import CompilerVersion
+
+# Cycle dependency
+if TYPE_CHECKING:
+    from crytic_compile import CryticCompile
+
+# pylint: disable=too-many-instance-attributes,too-many-public-methods
+class CompilationUnit:
+    def __init__(self, crytic_compile: "CryticCompile", unique_id: str):
+        # ASTS are indexed by absolute path
+        self._asts: Dict = {}
+
+        # ABI, bytecode and srcmap are indexed by contract_name
+        self._abis: Dict = {}
+        self._runtime_bytecodes: Dict = {}
+        self._init_bytecodes: Dict = {}
+        self._hashes: Dict = {}
+        self._events: Dict = {}
+        self._srcmaps: Dict[str, List[str]] = {}
+        self._srcmaps_runtime: Dict[str, List[str]] = {}
+
+        # set containing all the contract names
+        self._contracts_name: Set[str] = set()
+        # set containing all the contract name without the libraries
+        self._contracts_name_without_libraries: Optional[Set[str]] = None
+
+        # mapping from contract name to filename (naming.Filename)
+        self._contracts_filenames: Dict[str, Filename] = {}
+
+        # Libraries used by the contract
+        # contract_name -> (library, pattern)
+        self._libraries: Dict[str, List[Tuple[str, str]]] = {}
+
+        # Natspec
+        self._natspec: Dict[str, Natspec] = {}
+
+        # compiler.compiler
+        self._compiler_version: CompilerVersion = CompilerVersion(
+            compiler="N/A", version="N/A", optimized=False
+        )
+
+        self._crytic_compile: "CryticCompile" = crytic_compile
+        crytic_compile.compilation_units[unique_id] = self
+
+        self._unique_id = unique_id
+
+    @property
+    def unique_id(self):
+        return self._unique_id
+
+    @property
+    def crytic_compile(self) -> "CryticCompile":
+        return self._crytic_compile
+
+    ###################################################################################
+    ###################################################################################
+    # region Natspec
+    ###################################################################################
+    ###################################################################################
+
+    @property
+    def natspec(self):
+        """
+        Return the natspec of the contractse
+
+        :return: Dict[str, Natspec]
+        """
+        return self._natspec
+
+    ###################################################################################
+    ###################################################################################
+    # region Filenames
+    ###################################################################################
+    ###################################################################################
+
+    @property
+    def contracts_filenames(self) -> Dict[str, Filename]:
+        """
+        Return a dict contract_name -> Filename namedtuple (absolute, used)
+
+        :return: dict(name -> utils.namings.Filename)
+        """
+        return self._contracts_filenames
+
+    @property
+    def contracts_absolute_filenames(self) -> Dict[str, str]:
+        """
+        Return a dict (contract_name -> absolute filename)
+
+        :return:
+        """
+        return {k: f.absolute for (k, f) in self._contracts_filenames.items()}
+
+    def filename_of_contract(self, name: str) -> Filename:
+        """
+        :return: utils.namings.Filename
+        """
+        return self._contracts_filenames[name]
+
+    def absolute_filename_of_contract(self, name: str) -> str:
+        """
+        :return: Absolute filename
+        """
+        return self._contracts_filenames[name].absolute
+
+    def used_filename_of_contract(self, name: str) -> str:
+        """
+        :return: Used filename
+        """
+        return self._contracts_filenames[name].used
+
+    def find_absolute_filename_from_used_filename(self, used_filename: str) -> str:
+        """
+        Return the absolute filename based on the used one
+
+        :param used_filename:
+        :return: absolute filename
+        """
+        # Note: we could memoize this function if the third party end up using it heavily
+        # If used_filename is already an absolute pathn no need to lookup
+        if used_filename in self._crytic_compile.filenames:
+            return used_filename
+        d_file = {f.used: f.absolute for _, f in self._contracts_filenames.items()}
+        if used_filename not in d_file:
+            raise ValueError("f{filename} does not exist in {d}")
+        return d_file[used_filename]
+
+    def relative_filename_from_absolute_filename(self, absolute_filename: str) -> str:
+        """
+        Return the relative file based on the absolute name
+
+        :param absolute_filename:
+        :return:
+        """
+        d_file = {f.absolute: f.relative for _, f in self._contracts_filenames.items()}
+        if absolute_filename not in d_file:
+            raise ValueError("f{absolute_filename} does not exist in {d}")
+        return d_file[absolute_filename]
+
+    # endregion
+    ###################################################################################
+    ###################################################################################
+    # region Contract Names
+    ###################################################################################
+    ###################################################################################
+
+    @property
+    def contracts_names(self) -> Set[str]:
+        """
+        Return the contracts names
+
+        :return:
+        """
+        return self._contracts_name
+
+    @contracts_names.setter
+    def contracts_names(self, names: Set[str]):
+        """
+        Return the contracts names
+
+        :return:
+        """
+        self._contracts_name = names
+
+    @property
+    def contracts_names_without_libraries(self) -> Set[str]:
+        """
+        Return the contracts names (without the librairies)
+
+        :return:
+        """
+        if self._contracts_name_without_libraries is None:
+            libraries: List[str] = []
+            for contract_name in self._contracts_name:
+                libraries += self.libraries_names(contract_name)
+            self._contracts_name_without_libraries = {
+                l for l in self._contracts_name if l not in set(libraries)
+            }
+        return self._contracts_name_without_libraries
+
+    # endregion
+    ###################################################################################
+    ###################################################################################
+    # region ABI
+    ###################################################################################
+    ###################################################################################
+
+    @property
+    def abis(self) -> Dict:
+        """
+        Return the ABIs
+
+        :return:
+        """
+        return self._abis
+
+    def abi(self, name: str) -> Dict:
+        """
+        Get the ABI from a contract
+
+        :param name:
+        :return:
+        """
+        return self._abis.get(name, None)
+
+    # endregion
+    ###################################################################################
+    ###################################################################################
+    # region AST
+    ###################################################################################
+    ###################################################################################
+
+    @property
+    def asts(self) -> Dict:
+        """
+        Return the ASTs
+
+        :return: dict (absolute filename -> AST)
+        """
+        return self._asts
+
+    @asts.setter
+    def asts(self, value: Dict):
+        self._asts = value
+
+    def ast(self, path: str) -> Union[Dict, None]:
+        """
+        Return of the file
+
+        :param path:
+        :return:
+        """
+        if path not in self._asts:
+            try:
+                path = self.find_absolute_filename_from_used_filename(path)
+            except ValueError:
+                pass
+        return self._asts.get(path, None)
+
+    # endregion
+    ###################################################################################
+    ###################################################################################
+    # region Bytecode
+    ###################################################################################
+    ###################################################################################
+
+    @property
+    def bytecodes_runtime(self) -> Dict[str, str]:
+        """
+        Return the runtime bytecodes
+
+        :return:
+        """
+        return self._runtime_bytecodes
+
+    @bytecodes_runtime.setter
+    def bytecodes_runtime(self, bytecodes: Dict[str, str]):
+        """
+        Return the init bytecodes
+
+        :return:
+        """
+        self._runtime_bytecodes = bytecodes
+
+    @property
+    def bytecodes_init(self) -> Dict[str, str]:
+        """
+        Return the init bytecodes
+
+        :return:
+        """
+        return self._init_bytecodes
+
+    @bytecodes_init.setter
+    def bytecodes_init(self, bytecodes: Dict[str, str]):
+        """
+        Return the init bytecodes
+
+        :return:
+        """
+        self._init_bytecodes = bytecodes
+
+    def bytecode_runtime(self, name: str, libraries: Union[None, Dict[str, str]] = None) -> str:
+        """
+        Return the runtime bytecode of the contract. If library is provided, patch the bytecode
+
+        :param name:
+        :param libraries:
+        :return:
+        """
+        runtime = self._runtime_bytecodes.get(name, None)
+        return self._update_bytecode_with_libraries(runtime, libraries)
+
+    def bytecode_init(self, name: str, libraries: Union[None, Dict[str, str]] = None) -> str:
+        """
+        Return the init bytecode of the contract. If library is provided, patch the bytecode
+
+        :param name:
+        :param libraries:
+        :return:
+        """
+        init = self._init_bytecodes.get(name, None)
+        return self._update_bytecode_with_libraries(init, libraries)
+
+    # endregion
+    ###################################################################################
+    ###################################################################################
+    # region Source mapping
+    ###################################################################################
+    ###################################################################################
+
+    @property
+    def srcmaps_init(self) -> Dict[str, List[str]]:
+        """
+        Return the init srcmap
+
+        :return:
+        """
+        return self._srcmaps
+
+    @property
+    def srcmaps_runtime(self) -> Dict[str, List[str]]:
+        """
+        Return the runtime srcmap
+
+        :return:
+        """
+        return self._srcmaps_runtime
+
+    def srcmap_init(self, name: str) -> List[str]:
+        """
+        Return the init srcmap
+
+        :param name:
+        :return:
+        """
+        return self._srcmaps.get(name, [])
+
+    def srcmap_runtime(self, name: str) -> List[str]:
+        """
+        Return the runtime srcmap
+
+        :param name:
+        :return:
+        """
+        return self._srcmaps_runtime.get(name, [])
+
+    # endregion
+    ###################################################################################
+    ###################################################################################
+    # region Libraries
+    ###################################################################################
+    ###################################################################################
+
+    @property
+    def libraries(self) -> Dict[str, List[Tuple[str, str]]]:
+        """
+        Return the libraries used (contract_name -> [(library, pattern))])
+
+        :return:
+        """
+        return self._libraries
+
+    def _convert_libraries_names(self, libraries: Dict[str, str]) -> Dict[str, str]:
+        """
+        :param libraries: list(name, addr). Name can be the library name, or filename:library_name
+        :return:
+        """
+        new_names = {}
+        for (lib, addr) in libraries.items():
+            # Prior solidity 0.5
+            # libraries were on the format __filename:contract_name_____
+            # From solidity 0.5,
+            # libraries are on the format __$kecckack(filename:contract_name)[34]$__
+            # https://solidity.readthedocs.io/en/v0.5.7/050-breaking-changes.html#command-line-and-json-interfaces
+
+            lib_4 = "__" + lib + "_" * (38 - len(lib))
+
+            sha3_result = sha3.keccak_256()
+            sha3_result.update(lib.encode("utf-8"))
+            lib_5 = "__$" + sha3_result.hexdigest()[:34] + "$__"
+
+            new_names[lib] = addr
+            new_names[lib_4] = addr
+            new_names[lib_5] = addr
+
+            if lib in self.contracts_names:
+                lib_filename = self.contracts_filenames[lib]
+
+                lib_with_abs_filename = lib_filename.absolute + ":" + lib
+                lib_with_abs_filename = lib_with_abs_filename[0:36]
+
+                lib_4 = "__" + lib_with_abs_filename + "_" * (38 - len(lib_with_abs_filename))
+                new_names[lib_4] = addr
+
+                lib_with_used_filename = lib_filename.used + ":" + lib
+                lib_with_used_filename = lib_with_used_filename[0:36]
+
+                lib_4 = "__" + lib_with_used_filename + "_" * (38 - len(lib_with_used_filename))
+                new_names[lib_4] = addr
+
+                sha3_result = sha3.keccak_256()
+                sha3_result.update(lib_with_abs_filename.encode("utf-8"))
+                lib_5 = "__$" + sha3_result.hexdigest()[:34] + "$__"
+                new_names[lib_5] = addr
+
+                sha3_result = sha3.keccak_256()
+                sha3_result.update(lib_with_used_filename.encode("utf-8"))
+                lib_5 = "__$" + sha3_result.hexdigest()[:34] + "$__"
+                new_names[lib_5] = addr
+
+        return new_names
+
+    def _library_name_lookup(
+        self, lib_name: str, original_contract: str
+    ) -> Optional[Tuple[str, str]]:
+        """
+        Convert a library name to the contract
+        The library can be:
+        - the original contract name
+        - __X__ following Solidity 0.4 format
+        - __$..$__ following Solidity 0.5 format
+
+        :param lib_name:
+        :return: (contract name, pattern) (None if not found)
+        """
+
+        for name in self.contracts_names:
+            if name == lib_name:
+                return name, name
+
+            # Some platform use only the contract name
+            # Some use fimename:contract_name
+            name_with_absolute_filename = self.contracts_filenames[name].absolute + ":" + name
+            name_with_absolute_filename = name_with_absolute_filename[0:36]
+
+            name_with_used_filename = self.contracts_filenames[name].used + ":" + name
+            name_with_used_filename = name_with_used_filename[0:36]
+
+            # Solidity 0.4
+            solidity_0_4 = "__" + name + "_" * (38 - len(name))
+            if solidity_0_4 == lib_name:
+                return name, solidity_0_4
+
+            # Solidity 0.4 with filename
+            solidity_0_4_filename = (
+                "__" + name_with_absolute_filename + "_" * (38 - len(name_with_absolute_filename))
+            )
+            if solidity_0_4_filename == lib_name:
+                return name, solidity_0_4_filename
+
+            # Solidity 0.4 with filename
+            solidity_0_4_filename = (
+                "__" + name_with_used_filename + "_" * (38 - len(name_with_used_filename))
+            )
+            if solidity_0_4_filename == lib_name:
+                return name, solidity_0_4_filename
+
+            # Solidity 0.5
+            sha3_result = sha3.keccak_256()
+            sha3_result.update(name.encode("utf-8"))
+            v5_name = "__$" + sha3_result.hexdigest()[:34] + "$__"
+
+            if v5_name == lib_name:
+                return name, v5_name
+
+            # Solidity 0.5 with filename
+            sha3_result = sha3.keccak_256()
+            sha3_result.update(name_with_absolute_filename.encode("utf-8"))
+            v5_name = "__$" + sha3_result.hexdigest()[:34] + "$__"
+
+            if v5_name == lib_name:
+                return name, v5_name
+
+            sha3_result = sha3.keccak_256()
+            sha3_result.update(name_with_used_filename.encode("utf-8"))
+            v5_name = "__$" + sha3_result.hexdigest()[:34] + "$__"
+
+            if v5_name == lib_name:
+                return name, v5_name
+
+        # handle specific case of collision for Solidity <0.4
+        # We can only detect that the second contract is meant to be the library
+        # if there is only two contracts in the codebase
+        if len(self._contracts_name) == 2:
+            return next(
+                (
+                    (c, "__" + c + "_" * (38 - len(c)))
+                    for c in self._contracts_name
+                    if c != original_contract
+                ),
+                None,
+            )
+
+        return None
+
+    def libraries_names(self, name: str) -> List[str]:
+        """
+        Return the name of the libraries used by the contract
+
+        :param name: contract
+        :return: list of libraries name
+        """
+
+        if name not in self._libraries:
+            init = re.findall(r"__.{36}__", self.bytecode_init(name))
+            runtime = re.findall(r"__.{36}__", self.bytecode_runtime(name))
+            libraires = [self._library_name_lookup(x, name) for x in set(init + runtime)]
+            self._libraries[name] = [lib for lib in libraires if lib]
+        return [name for (name, pattern) in self._libraries[name]]
+
+    def libraries_names_and_patterns(self, name):
+        """
+        Return the name of the libraries used by the contract
+
+        :param name: contract
+        :return: list of (libraries name, pattern)
+        """
+
+        if name not in self._libraries:
+            init = re.findall(r"__.{36}__", self.bytecode_init(name))
+            runtime = re.findall(r"__.{36}__", self.bytecode_runtime(name))
+            libraires = [self._library_name_lookup(x, name) for x in set(init + runtime)]
+            self._libraries[name] = [lib for lib in libraires if lib]
+        return self._libraries[name]
+
+    def _update_bytecode_with_libraries(
+        self, bytecode: str, libraries: Union[None, Dict[str, str]]
+    ) -> str:
+        """
+        Patch the bytecode
+
+        :param bytecode:
+        :param libraries:
+        :return:
+        """
+        if libraries:
+            libraries = self._convert_libraries_names(libraries)
+            for library_found in re.findall(r"__.{36}__", bytecode):
+                if library_found in libraries:
+                    bytecode = re.sub(
+                        re.escape(library_found),
+                        "{:040x}".format(libraries[library_found]),
+                        bytecode,
+                    )
+        return bytecode
+
+    # endregion
+    ###################################################################################
+    ###################################################################################
+    # region Hashes
+    ###################################################################################
+    ###################################################################################
+
+    def hashes(self, name: str) -> Dict[str, int]:
+        """
+        Return the hashes of the functions
+
+        :param name:
+        :return:
+        """
+        if not name in self._hashes:
+            self._compute_hashes(name)
+        return self._hashes[name]
+
+    def _compute_hashes(self, name: str):
+        self._hashes[name] = {}
+        for sig in self.abi(name):
+            if "type" in sig:
+                if sig["type"] == "function":
+                    sig_name = sig["name"]
+                    arguments = ",".join([x["type"] for x in sig["inputs"]])
+                    sig = f"{sig_name}({arguments})"
+                    sha3_result = sha3.keccak_256()
+                    sha3_result.update(sig.encode("utf-8"))
+                    self._hashes[name][sig] = int("0x" + sha3_result.hexdigest()[:8], 16)
+
+    # endregion
+    ###################################################################################
+    ###################################################################################
+    # region Events
+    ###################################################################################
+    ###################################################################################
+
+    def events_topics(self, name: str) -> Dict[str, Tuple[int, List[bool]]]:
+        """
+        Return the topics of the contract'sevents
+        :param name: contract
+        :return: A dictionary {event signature -> topic hash, [is_indexed for each parameter]}
+        """
+        if not name in self._events:
+            self._compute_topics_events(name)
+        return self._events[name]
+
+    def _compute_topics_events(self, name: str):
+        self._events[name] = {}
+        for sig in self.abi(name):
+            if "type" in sig:
+                if sig["type"] == "event":
+                    sig_name = sig["name"]
+                    arguments = ",".join([x["type"] for x in sig["inputs"]])
+                    indexes = [x.get("indexed", False) for x in sig["inputs"]]
+                    sig = f"{sig_name}({arguments})"
+                    sha3_result = sha3.keccak_256()
+                    sha3_result.update(sig.encode("utf-8"))
+
+                    self._events[name][sig] = (int("0x" + sha3_result.hexdigest()[:8], 16), indexes)
+
+    # endregion
+    ###################################################################################
+    ###################################################################################
+    # region Metadata
+    ###################################################################################
+    ###################################################################################
+
+    def remove_metadata(self):
+        """
+        Init bytecode contains metadata that needs to be removed
+        see
+        http://solidity.readthedocs.io/en/v0.4.24/metadata.html#encoding-of-the-metadata-hash-in-the-bytecode
+        """
+        self._init_bytecodes = {
+            key: re.sub(r"a165627a7a72305820.{64}0029", r"", bytecode)
+            for (key, bytecode) in self._init_bytecodes.items()
+        }
+
+        self._runtime_bytecodes = {
+            key: re.sub(r"a165627a7a72305820.{64}0029", r"", bytecode)
+            for (key, bytecode) in self._runtime_bytecodes.items()
+        }
+
+    # endregion
+    ###################################################################################
+    ###################################################################################
+    # region Compiler information
+    ###################################################################################
+    ###################################################################################
+
+    @property
+    def compiler_version(self) -> "CompilerVersion":
+        """
+        Return the compiler used as a namedtuple(compiler, version)
+
+        :return:
+        """
+        return self._compiler_version
+
+    @compiler_version.setter
+    def compiler_version(self, compiler):
+        self._compiler_version = compiler

--- a/crytic_compile/compilation_unit.py
+++ b/crytic_compile/compilation_unit.py
@@ -1,4 +1,5 @@
 import re
+import uuid
 from typing import TYPE_CHECKING, Dict, List, Optional, Set, Tuple, Union
 
 import sha3
@@ -47,6 +48,10 @@ class CompilationUnit:
         )
 
         self._crytic_compile: "CryticCompile" = crytic_compile
+
+        if unique_id == ".":
+            unique_id = uuid.uuid4()
+
         crytic_compile.compilation_units[unique_id] = self
 
         self._unique_id = unique_id

--- a/crytic_compile/crytic_compile.py
+++ b/crytic_compile/crytic_compile.py
@@ -123,6 +123,17 @@ class CryticCompile:
         """
         return self._compilation_units
 
+    def is_in_multiple_compilation_unit(self, contract: str) -> bool:
+        """
+        Check if the contract is share by multiple compilation unit
+
+        """
+        count = 0
+        for compilation_unit in self._compilation_units.values():
+            if contract in compilation_unit.contracts_names:
+                count += 1
+        return count >= 2
+
     ###################################################################################
     ###################################################################################
     # region Filenames

--- a/crytic_compile/crytic_compile.py
+++ b/crytic_compile/crytic_compile.py
@@ -6,26 +6,23 @@ import inspect
 import json
 import logging
 import os
-import re
 import subprocess
 from pathlib import Path
 from typing import TYPE_CHECKING, Dict, List, Optional, Set, Tuple, Type, Union
 
-import sha3
-
+from crytic_compile.compilation_unit import CompilationUnit
 from crytic_compile.platform import all_platforms, solc_standard_json
 from crytic_compile.platform.abstract_platform import AbstractPlatform
 from crytic_compile.platform.all_export import PLATFORMS_EXPORT
 from crytic_compile.platform.solc import Solc
 from crytic_compile.platform.standard import export_to_standard
 from crytic_compile.utils.naming import Filename
-from crytic_compile.utils.natspec import Natspec
 from crytic_compile.utils.npm import get_package_name
 from crytic_compile.utils.zip import load_from_zip
 
 # Cycle dependency
 if TYPE_CHECKING:
-    from crytic_compile.compiler.compiler import CompilerVersion
+    pass
 
 LOGGER = logging.getLogger("CryticCompile")
 logging.basicConfig()
@@ -56,7 +53,7 @@ def is_supported(target: str) -> bool:
     return any(platform.is_supported(target) for platform in platforms) or target.endswith(".zip")
 
 
-# pylint: disable=too-many-instance-attributes,too-many-public-methods
+# pylint: disable=too-many-instance-attributes
 class CryticCompile:
     """
     Main class.
@@ -69,32 +66,17 @@ class CryticCompile:
         Keyword Args:
             See https://github.com/crytic/crytic-compile/wiki/Configuration
         """
-        # ASTS are indexed by absolute path
-        self._asts: Dict = {}
 
-        # ABI, bytecode and srcmap are indexed by contract_name
-        self._abis: Dict = {}
-        self._runtime_bytecodes: Dict = {}
-        self._init_bytecodes: Dict = {}
-        self._hashes: Dict = {}
-        self._events: Dict = {}
-        self._srcmaps: Dict[str, List[str]] = {}
-        self._srcmaps_runtime: Dict[str, List[str]] = {}
-        self._src_content: Dict = {}
         # dependencies is needed for platform conversion
         self._dependencies: Set = set()
 
-        # set containing all the contract names
-        self._contracts_name: Set[str] = set()
-        # set containing all the contract name without the libraries
-        self._contracts_name_without_libraries: Optional[Set[str]] = None
-
         # set containing all the filenames
         self._filenames: Set[Filename] = set()
-        # mapping from contract name to filename (naming.Filename)
-        self._contracts_filenames: Dict[str, Filename] = {}
+
         # mapping from absolute/relative/used to filename
         self._filenames_lookup: Optional[Dict[str, Filename]] = None
+
+        self._src_content: Dict = {}
 
         # Mapping each file to
         #  offset -> line, column
@@ -107,18 +89,6 @@ class CryticCompile:
         # Note: line 1 is at index 0
         self._cached_line_to_code: Dict[Filename, List[bytes]] = dict()
 
-        # Libraries used by the contract
-        # contract_name -> (library, pattern)
-        self._libraries: Dict[str, List[Tuple[str, str]]] = {}
-
-        self._bytecode_only = False
-
-        # Natspec
-        self._natspec: Dict[str, Natspec] = {}
-
-        # compiler.compiler
-        self._compiler_version: Optional["CompilerVersion"] = None
-
         self._working_dir = Path.cwd()
 
         if isinstance(target, str):
@@ -130,9 +100,9 @@ class CryticCompile:
 
         self._platform: AbstractPlatform = platform
 
-        # If its a exported archive, we use compilation index 0.
-        # if isinstance(target, dict):
-        #    target = (target, 0)
+        self._compilation_units: Dict[str, CompilationUnit] = {}
+
+        self._bytecode_only = False
 
         self._compile(**kwargs)
 
@@ -145,20 +115,13 @@ class CryticCompile:
         """
         return self._platform.target
 
-    ###################################################################################
-    ###################################################################################
-    # region Natspec
-    ###################################################################################
-    ###################################################################################
-
     @property
-    def natspec(self):
+    def compilation_units(self) -> Dict[str, CompilationUnit]:
         """
-        Return the natspec of the contractse
+        Return the dict id -> compilation unit
 
-        :return: Dict[str, Natspec]
         """
-        return self._natspec
+        return self._compilation_units
 
     ###################################################################################
     ###################################################################################
@@ -176,70 +139,6 @@ class CryticCompile:
     @filenames.setter
     def filenames(self, all_filenames: Set[Filename]):
         self._filenames = all_filenames
-
-    @property
-    def contracts_filenames(self) -> Dict[str, Filename]:
-        """
-        Return a dict contract_name -> Filename namedtuple (absolute, used)
-
-        :return: dict(name -> utils.namings.Filename)
-        """
-        return self._contracts_filenames
-
-    @property
-    def contracts_absolute_filenames(self) -> Dict[str, str]:
-        """
-        Return a dict (contract_name -> absolute filename)
-
-        :return:
-        """
-        return {k: f.absolute for (k, f) in self._contracts_filenames.items()}
-
-    def filename_of_contract(self, name: str) -> Filename:
-        """
-        :return: utils.namings.Filename
-        """
-        return self._contracts_filenames[name]
-
-    def absolute_filename_of_contract(self, name: str) -> str:
-        """
-        :return: Absolute filename
-        """
-        return self._contracts_filenames[name].absolute
-
-    def used_filename_of_contract(self, name: str) -> str:
-        """
-        :return: Used filename
-        """
-        return self._contracts_filenames[name].used
-
-    def find_absolute_filename_from_used_filename(self, used_filename: str) -> str:
-        """
-        Return the absolute filename based on the used one
-
-        :param used_filename:
-        :return: absolute filename
-        """
-        # Note: we could memoize this function if the third party end up using it heavily
-        # If used_filename is already an absolute pathn no need to lookup
-        if used_filename in self._filenames:
-            return used_filename
-        d_file = {f.used: f.absolute for _, f in self._contracts_filenames.items()}
-        if used_filename not in d_file:
-            raise ValueError("f{filename} does not exist in {d}")
-        return d_file[used_filename]
-
-    def relative_filename_from_absolute_filename(self, absolute_filename: str) -> str:
-        """
-        Return the relative file based on the absolute name
-
-        :param absolute_filename:
-        :return:
-        """
-        d_file = {f.absolute: f.relative for _, f in self._contracts_filenames.items()}
-        if absolute_filename not in d_file:
-            raise ValueError("f{absolute_filename} does not exist in {d}")
-        return d_file[absolute_filename]
 
     def filename_lookup(self, filename: str) -> Filename:
         """
@@ -304,7 +203,7 @@ class CryticCompile:
 
         source_code = self._cached_line_to_code[file]
         acc = 0
-        lines_delimiters: Dict[int, Tuple[int, acc]] = dict()
+        lines_delimiters: Dict[int, Tuple[int, int]] = dict()
         for line_number, x in enumerate(source_code):
             for i in range(acc, acc + len(x)):
                 lines_delimiters[i] = (line_number + 1, i - acc + 1)
@@ -340,214 +239,6 @@ class CryticCompile:
         if line - 1 < 0 or line - 1 >= len(lines):
             return None
         return lines[line - 1]
-
-    # endregion
-    ###################################################################################
-    ###################################################################################
-    # region Contract Names
-    ###################################################################################
-    ###################################################################################
-
-    @property
-    def contracts_names(self) -> Set[str]:
-        """
-        Return the contracts names
-
-        :return:
-        """
-        return self._contracts_name
-
-    @contracts_names.setter
-    def contracts_names(self, names: Set[str]):
-        """
-        Return the contracts names
-
-        :return:
-        """
-        self._contracts_name = names
-
-    @property
-    def contracts_names_without_libraries(self) -> Set[str]:
-        """
-        Return the contracts names (without the librairies)
-
-        :return:
-        """
-        if self._contracts_name_without_libraries is None:
-            libraries: List[str] = []
-            for contract_name in self._contracts_name:
-                libraries += self.libraries_names(contract_name)
-            self._contracts_name_without_libraries = {
-                l for l in self._contracts_name if l not in set(libraries)
-            }
-        return self._contracts_name_without_libraries
-
-    # endregion
-    ###################################################################################
-    ###################################################################################
-    # region ABI
-    ###################################################################################
-    ###################################################################################
-
-    @property
-    def abis(self) -> Dict:
-        """
-        Return the ABIs
-
-        :return:
-        """
-        return self._abis
-
-    def abi(self, name: str) -> Dict:
-        """
-        Get the ABI from a contract
-
-        :param name:
-        :return:
-        """
-        return self._abis.get(name, None)
-
-    # endregion
-    ###################################################################################
-    ###################################################################################
-    # region AST
-    ###################################################################################
-    ###################################################################################
-
-    @property
-    def asts(self) -> Dict:
-        """
-        Return the ASTs
-
-        :return: dict (absolute filename -> AST)
-        """
-        return self._asts
-
-    @asts.setter
-    def asts(self, value: Dict):
-        self._asts = value
-
-    def ast(self, path: str) -> Union[Dict, None]:
-        """
-        Return of the file
-
-        :param path:
-        :return:
-        """
-        if path not in self._asts:
-            try:
-                path = self.find_absolute_filename_from_used_filename(path)
-            except ValueError:
-                pass
-        return self._asts.get(path, None)
-
-    # endregion
-    ###################################################################################
-    ###################################################################################
-    # region Bytecode
-    ###################################################################################
-    ###################################################################################
-
-    @property
-    def bytecodes_runtime(self) -> Dict[str, str]:
-        """
-        Return the runtime bytecodes
-
-        :return:
-        """
-        return self._runtime_bytecodes
-
-    @bytecodes_runtime.setter
-    def bytecodes_runtime(self, bytecodes: Dict[str, str]):
-        """
-        Return the init bytecodes
-
-        :return:
-        """
-        self._runtime_bytecodes = bytecodes
-
-    @property
-    def bytecodes_init(self) -> Dict[str, str]:
-        """
-        Return the init bytecodes
-
-        :return:
-        """
-        return self._init_bytecodes
-
-    @bytecodes_init.setter
-    def bytecodes_init(self, bytecodes: Dict[str, str]):
-        """
-        Return the init bytecodes
-
-        :return:
-        """
-        self._init_bytecodes = bytecodes
-
-    def bytecode_runtime(self, name: str, libraries: Union[None, Dict[str, str]] = None) -> str:
-        """
-        Return the runtime bytecode of the contract. If library is provided, patch the bytecode
-
-        :param name:
-        :param libraries:
-        :return:
-        """
-        runtime = self._runtime_bytecodes.get(name, None)
-        return self._update_bytecode_with_libraries(runtime, libraries)
-
-    def bytecode_init(self, name: str, libraries: Union[None, Dict[str, str]] = None) -> str:
-        """
-        Return the init bytecode of the contract. If library is provided, patch the bytecode
-
-        :param name:
-        :param libraries:
-        :return:
-        """
-        init = self._init_bytecodes.get(name, None)
-        return self._update_bytecode_with_libraries(init, libraries)
-
-    # endregion
-    ###################################################################################
-    ###################################################################################
-    # region Source mapping
-    ###################################################################################
-    ###################################################################################
-
-    @property
-    def srcmaps_init(self) -> Dict[str, List[str]]:
-        """
-        Return the init srcmap
-
-        :return:
-        """
-        return self._srcmaps
-
-    @property
-    def srcmaps_runtime(self) -> Dict[str, List[str]]:
-        """
-        Return the runtime srcmap
-
-        :return:
-        """
-        return self._srcmaps_runtime
-
-    def srcmap_init(self, name: str) -> List[str]:
-        """
-        Return the init srcmap
-
-        :param name:
-        :return:
-        """
-        return self._srcmaps.get(name, [])
-
-    def srcmap_runtime(self, name: str) -> List[str]:
-        """
-        Return the runtime srcmap
-
-        :param name:
-        :return:
-        """
-        return self._srcmaps_runtime.get(name, [])
 
     @property
     def src_content(self) -> Dict[str, str]:
@@ -619,19 +310,6 @@ class CryticCompile:
     ###################################################################################
 
     @property
-    def compiler_version(self) -> Union[None, "CompilerVersion"]:
-        """
-        Return the compiler used as a namedtuple(compiler, version)
-
-        :return:
-        """
-        return self._compiler_version
-
-    @compiler_version.setter
-    def compiler_version(self, compiler):
-        self._compiler_version = compiler
-
-    @property
     def bytecode_only(self) -> bool:
         """
         Return true if only the bytecode was retrieved
@@ -643,267 +321,6 @@ class CryticCompile:
     @bytecode_only.setter
     def bytecode_only(self, bytecode):
         self._bytecode_only = bytecode
-
-    # endregion
-    ###################################################################################
-    ###################################################################################
-    # region Libraries
-    ###################################################################################
-    ###################################################################################
-
-    @property
-    def libraries(self) -> Dict[str, List[Tuple[str, str]]]:
-        """
-        Return the libraries used (contract_name -> [(library, pattern))])
-
-        :return:
-        """
-        return self._libraries
-
-    def _convert_libraries_names(self, libraries: Dict[str, str]) -> Dict[str, str]:
-        """
-        :param libraries: list(name, addr). Name can be the library name, or filename:library_name
-        :return:
-        """
-        new_names = {}
-        for (lib, addr) in libraries.items():
-            # Prior solidity 0.5
-            # libraries were on the format __filename:contract_name_____
-            # From solidity 0.5,
-            # libraries are on the format __$kecckack(filename:contract_name)[34]$__
-            # https://solidity.readthedocs.io/en/v0.5.7/050-breaking-changes.html#command-line-and-json-interfaces
-
-            lib_4 = "__" + lib + "_" * (38 - len(lib))
-
-            sha3_result = sha3.keccak_256()
-            sha3_result.update(lib.encode("utf-8"))
-            lib_5 = "__$" + sha3_result.hexdigest()[:34] + "$__"
-
-            new_names[lib] = addr
-            new_names[lib_4] = addr
-            new_names[lib_5] = addr
-
-            if lib in self.contracts_names:
-                lib_filename = self.contracts_filenames[lib]
-
-                lib_with_abs_filename = lib_filename.absolute + ":" + lib
-                lib_with_abs_filename = lib_with_abs_filename[0:36]
-
-                lib_4 = "__" + lib_with_abs_filename + "_" * (38 - len(lib_with_abs_filename))
-                new_names[lib_4] = addr
-
-                lib_with_used_filename = lib_filename.used + ":" + lib
-                lib_with_used_filename = lib_with_used_filename[0:36]
-
-                lib_4 = "__" + lib_with_used_filename + "_" * (38 - len(lib_with_used_filename))
-                new_names[lib_4] = addr
-
-                sha3_result = sha3.keccak_256()
-                sha3_result.update(lib_with_abs_filename.encode("utf-8"))
-                lib_5 = "__$" + sha3_result.hexdigest()[:34] + "$__"
-                new_names[lib_5] = addr
-
-                sha3_result = sha3.keccak_256()
-                sha3_result.update(lib_with_used_filename.encode("utf-8"))
-                lib_5 = "__$" + sha3_result.hexdigest()[:34] + "$__"
-                new_names[lib_5] = addr
-
-        return new_names
-
-    def _library_name_lookup(
-        self, lib_name: str, original_contract: str
-    ) -> Optional[Tuple[str, str]]:
-        """
-        Convert a library name to the contract
-        The library can be:
-        - the original contract name
-        - __X__ following Solidity 0.4 format
-        - __$..$__ following Solidity 0.5 format
-
-        :param lib_name:
-        :return: (contract name, pattern) (None if not found)
-        """
-
-        for name in self.contracts_names:
-            if name == lib_name:
-                return name, name
-
-            # Some platform use only the contract name
-            # Some use fimename:contract_name
-            name_with_absolute_filename = self.contracts_filenames[name].absolute + ":" + name
-            name_with_absolute_filename = name_with_absolute_filename[0:36]
-
-            name_with_used_filename = self.contracts_filenames[name].used + ":" + name
-            name_with_used_filename = name_with_used_filename[0:36]
-
-            # Solidity 0.4
-            solidity_0_4 = "__" + name + "_" * (38 - len(name))
-            if solidity_0_4 == lib_name:
-                return name, solidity_0_4
-
-            # Solidity 0.4 with filename
-            solidity_0_4_filename = (
-                "__" + name_with_absolute_filename + "_" * (38 - len(name_with_absolute_filename))
-            )
-            if solidity_0_4_filename == lib_name:
-                return name, solidity_0_4_filename
-
-            # Solidity 0.4 with filename
-            solidity_0_4_filename = (
-                "__" + name_with_used_filename + "_" * (38 - len(name_with_used_filename))
-            )
-            if solidity_0_4_filename == lib_name:
-                return name, solidity_0_4_filename
-
-            # Solidity 0.5
-            sha3_result = sha3.keccak_256()
-            sha3_result.update(name.encode("utf-8"))
-            v5_name = "__$" + sha3_result.hexdigest()[:34] + "$__"
-
-            if v5_name == lib_name:
-                return name, v5_name
-
-            # Solidity 0.5 with filename
-            sha3_result = sha3.keccak_256()
-            sha3_result.update(name_with_absolute_filename.encode("utf-8"))
-            v5_name = "__$" + sha3_result.hexdigest()[:34] + "$__"
-
-            if v5_name == lib_name:
-                return name, v5_name
-
-            sha3_result = sha3.keccak_256()
-            sha3_result.update(name_with_used_filename.encode("utf-8"))
-            v5_name = "__$" + sha3_result.hexdigest()[:34] + "$__"
-
-            if v5_name == lib_name:
-                return name, v5_name
-
-        # handle specific case of collision for Solidity <0.4
-        # We can only detect that the second contract is meant to be the library
-        # if there is only two contracts in the codebase
-        if len(self._contracts_name) == 2:
-            return next(
-                (
-                    (c, "__" + c + "_" * (38 - len(c)))
-                    for c in self._contracts_name
-                    if c != original_contract
-                ),
-                None,
-            )
-
-        return None
-
-    def libraries_names(self, name: str) -> List[str]:
-        """
-        Return the name of the libraries used by the contract
-
-        :param name: contract
-        :return: list of libraries name
-        """
-
-        if name not in self._libraries:
-            init = re.findall(r"__.{36}__", self.bytecode_init(name))
-            runtime = re.findall(r"__.{36}__", self.bytecode_runtime(name))
-            libraires = [self._library_name_lookup(x, name) for x in set(init + runtime)]
-            self._libraries[name] = [lib for lib in libraires if lib]
-        return [name for (name, pattern) in self._libraries[name]]
-
-    def libraries_names_and_patterns(self, name):
-        """
-        Return the name of the libraries used by the contract
-
-        :param name: contract
-        :return: list of (libraries name, pattern)
-        """
-
-        if name not in self._libraries:
-            init = re.findall(r"__.{36}__", self.bytecode_init(name))
-            runtime = re.findall(r"__.{36}__", self.bytecode_runtime(name))
-            libraires = [self._library_name_lookup(x, name) for x in set(init + runtime)]
-            self._libraries[name] = [lib for lib in libraires if lib]
-        return self._libraries[name]
-
-    def _update_bytecode_with_libraries(
-        self, bytecode: str, libraries: Union[None, Dict[str, str]]
-    ) -> str:
-        """
-        Patch the bytecode
-
-        :param bytecode:
-        :param libraries:
-        :return:
-        """
-        if libraries:
-            libraries = self._convert_libraries_names(libraries)
-            for library_found in re.findall(r"__.{36}__", bytecode):
-                if library_found in libraries:
-                    bytecode = re.sub(
-                        re.escape(library_found),
-                        "{:040x}".format(libraries[library_found]),
-                        bytecode,
-                    )
-        return bytecode
-
-    # endregion
-    ###################################################################################
-    ###################################################################################
-    # region Hashes
-    ###################################################################################
-    ###################################################################################
-
-    def hashes(self, name: str) -> Dict[str, int]:
-        """
-        Return the hashes of the functions
-
-        :param name:
-        :return:
-        """
-        if not name in self._hashes:
-            self._compute_hashes(name)
-        return self._hashes[name]
-
-    def _compute_hashes(self, name: str):
-        self._hashes[name] = {}
-        for sig in self.abi(name):
-            if "type" in sig:
-                if sig["type"] == "function":
-                    sig_name = sig["name"]
-                    arguments = ",".join([x["type"] for x in sig["inputs"]])
-                    sig = f"{sig_name}({arguments})"
-                    sha3_result = sha3.keccak_256()
-                    sha3_result.update(sig.encode("utf-8"))
-                    self._hashes[name][sig] = int("0x" + sha3_result.hexdigest()[:8], 16)
-
-    # endregion
-    ###################################################################################
-    ###################################################################################
-    # region Events
-    ###################################################################################
-    ###################################################################################
-
-    def events_topics(self, name: str) -> Dict[str, Tuple[int, List[bool]]]:
-        """
-        Return the topics of the contract'sevents
-        :param name: contract
-        :return: A dictionary {event signature -> topic hash, [is_indexed for each parameter]}
-        """
-        if not name in self._events:
-            self._compute_topics_events(name)
-        return self._events[name]
-
-    def _compute_topics_events(self, name: str):
-        self._events[name] = {}
-        for sig in self.abi(name):
-            if "type" in sig:
-                if sig["type"] == "event":
-                    sig_name = sig["name"]
-                    arguments = ",".join([x["type"] for x in sig["inputs"]])
-                    indexes = [x.get("indexed", False) for x in sig["inputs"]]
-                    sig = f"{sig_name}({arguments})"
-                    sha3_result = sha3.keccak_256()
-                    sha3_result.update(sig.encode("utf-8"))
-
-                    self._events[name][sig] = (int("0x" + sha3_result.hexdigest()[:8], 16), indexes)
 
     # endregion
     ###################################################################################
@@ -940,7 +357,7 @@ class CryticCompile:
     ###################################################################################
     ###################################################################################
 
-    def export(self, **kwargs: str) -> Optional[str]:
+    def export(self, **kwargs: str) -> List[str]:
         """
         Export to json. The json format can be crytic-compile, solc or truffle.
         """
@@ -988,7 +405,8 @@ class CryticCompile:
 
         remove_metadata = kwargs.get("compile_remove_metadata", False)
         if remove_metadata:
-            self._remove_metadata()
+            for compilation_unit in self._compilation_units.values():
+                compilation_unit.remove_metadata()
 
     @staticmethod
     def _run_custom_build(custom_build: str):
@@ -1004,29 +422,6 @@ class CryticCompile:
         LOGGER.info(stdout)
         if stderr:
             LOGGER.error("Custom build error: \n%s", stderr)
-
-    # endregion
-    ###################################################################################
-    ###################################################################################
-    # region Metadata
-    ###################################################################################
-    ###################################################################################
-
-    def _remove_metadata(self):
-        """
-        Init bytecode contains metadata that needs to be removed
-        see
-        http://solidity.readthedocs.io/en/v0.4.24/metadata.html#encoding-of-the-metadata-hash-in-the-bytecode
-        """
-        self._init_bytecodes = {
-            key: re.sub(r"a165627a7a72305820.{64}0029", r"", bytecode)
-            for (key, bytecode) in self._init_bytecodes.items()
-        }
-
-        self._runtime_bytecodes = {
-            key: re.sub(r"a165627a7a72305820.{64}0029", r"", bytecode)
-            for (key, bytecode) in self._runtime_bytecodes.items()
-        }
 
     # endregion
     ###################################################################################

--- a/crytic_compile/platform/abstract_platform.py
+++ b/crytic_compile/platform/abstract_platform.py
@@ -2,7 +2,6 @@
 Abstract Platform
 """
 import abc
-from pathlib import Path
 from typing import TYPE_CHECKING, List, Dict
 
 from crytic_compile.platform import Type
@@ -49,7 +48,7 @@ class AbstractPlatform(metaclass=abc.ABCMeta):
             )
 
         self._target: str = target
-        self._cached_dependencies: Dict[Path, bool] = dict()
+        self._cached_dependencies: Dict[str, bool] = dict()
 
     # region Properties.
     ###################################################################################

--- a/crytic_compile/platform/archive.py
+++ b/crytic_compile/platform/archive.py
@@ -19,7 +19,7 @@ if TYPE_CHECKING:
     from crytic_compile import CryticCompile
 
 
-def export_to_archive(crytic_compile: "CryticCompile", **kwargs) -> str:
+def export_to_archive(crytic_compile: "CryticCompile", **kwargs) -> List[str]:
     """
     Export the archive
 
@@ -40,7 +40,7 @@ def export_to_archive(crytic_compile: "CryticCompile", **kwargs) -> str:
     with open(path, "w", encoding="utf8") as f_path:
         json.dump(output, f_path)
 
-    return path
+    return [path]
 
 
 class Archive(AbstractPlatform):

--- a/crytic_compile/platform/hardhat.py
+++ b/crytic_compile/platform/hardhat.py
@@ -17,6 +17,7 @@ from .abstract_platform import AbstractPlatform
 
 # Handle cycle
 from .solc import relative_to_short
+from ..compilation_unit import CompilationUnit
 
 if TYPE_CHECKING:
     from crytic_compile import CryticCompile
@@ -45,9 +46,6 @@ class Hardhat(AbstractPlatform):
         hardhat_ignore_compile = kwargs.get("hardhat_ignore_compile", False) or kwargs.get(
             "ignore_compile", False
         )
-
-        cache_directory = kwargs.get("hardhat_cache_directory", "cache")
-        config_file = Path(cache_directory, "solidity-files-cache.json")
 
         build_directory = Path(kwargs.get("hardhat_artifacts_directory", "artifacts"), "build-info")
 
@@ -79,75 +77,88 @@ class Hardhat(AbstractPlatform):
             if stderr:
                 LOGGER.error(stderr)
 
-        (compiler, version_from_config, optimized) = _get_version_from_config(config_file)
-
-        crytic_compile.compiler_version = CompilerVersion(
-            compiler=compiler, version=version_from_config, optimized=optimized
-        )
-
-        skip_filename = crytic_compile.compiler_version.version in [
-            f"0.4.{x}" for x in range(0, 10)
-        ]
-
         files = sorted(
             os.listdir(build_directory), key=lambda x: os.path.getmtime(Path(build_directory, x))
         )
+        files = [f for f in files if f.endswith(".json")]
         if not files:
             txt = f"`hardhat compile` failed. Can you run it?\n{build_directory} is empty"
             raise InvalidCompilation(txt)
 
-        build_info = Path(build_directory, files[0])
-        with open(build_info, encoding="utf8") as file_desc:
-            targets_json = json.load(file_desc)["output"]
+        for file in files:
+            build_info = Path(build_directory, file)
 
-            if "contracts" in targets_json:
-                for original_filename, contracts_info in targets_json["contracts"].items():
-                    for original_contract_name, info in contracts_info.items():
-                        contract_name = extract_name(original_contract_name)
+            compilation_unit = CompilationUnit(crytic_compile, file)
 
-                        contract_filename = convert_filename(
-                            original_filename,
-                            relative_to_short,
-                            crytic_compile,
-                            working_dir=hardhat_working_dir,
-                        )
+            with open(build_info, encoding="utf8") as file_desc:
+                loaded_json = json.load(file_desc)
 
-                        crytic_compile.contracts_names.add(contract_name)
-                        crytic_compile.contracts_filenames[contract_name] = contract_filename
+                targets_json = loaded_json["output"]
 
-                        crytic_compile.abis[contract_name] = info["abi"]
-                        crytic_compile.bytecodes_init[contract_name] = info["evm"]["bytecode"][
-                            "object"
-                        ]
-                        crytic_compile.bytecodes_runtime[contract_name] = info["evm"][
-                            "deployedBytecode"
-                        ]["object"]
-                        crytic_compile.srcmaps_init[contract_name] = info["evm"]["bytecode"][
-                            "sourceMap"
-                        ].split(";")
-                        crytic_compile.srcmaps_runtime[contract_name] = info["evm"][
-                            "deployedBytecode"
-                        ]["sourceMap"].split(";")
-                        userdoc = info.get("userdoc", {})
-                        devdoc = info.get("devdoc", {})
-                        natspec = Natspec(userdoc, devdoc)
-                        crytic_compile.natspec[contract_name] = natspec
+                version_from_config = loaded_json["solcVersion"]  # TODO supper vyper
+                input_json = loaded_json["input"]
+                compiler = "solc" if input_json["language"] == "Solidity" else "vyper"
+                optimized = input_json["settings"]["optimizer"]["enabled"]
 
-            if "sources" in targets_json:
-                for path, info in targets_json["sources"].items():
-                    if skip_filename:
-                        path = convert_filename(
-                            self._target,
-                            relative_to_short,
-                            crytic_compile,
-                            working_dir=hardhat_working_dir,
-                        )
-                    else:
-                        path = convert_filename(
-                            path, relative_to_short, crytic_compile, working_dir=hardhat_working_dir
-                        )
-                    crytic_compile.filenames.add(path)
-                    crytic_compile.asts[path.absolute] = info["ast"]
+                compilation_unit.compiler_version = CompilerVersion(
+                    compiler=compiler, version=version_from_config, optimized=optimized
+                )
+
+                skip_filename = compilation_unit.compiler_version.version in [
+                    f"0.4.{x}" for x in range(0, 10)
+                ]
+
+                if "contracts" in targets_json:
+                    for original_filename, contracts_info in targets_json["contracts"].items():
+                        for original_contract_name, info in contracts_info.items():
+                            contract_name = extract_name(original_contract_name)
+
+                            contract_filename = convert_filename(
+                                original_filename,
+                                relative_to_short,
+                                crytic_compile,
+                                working_dir=hardhat_working_dir,
+                            )
+
+                            compilation_unit.contracts_names.add(contract_name)
+                            compilation_unit.contracts_filenames[contract_name] = contract_filename
+
+                            compilation_unit.abis[contract_name] = info["abi"]
+                            compilation_unit.bytecodes_init[contract_name] = info["evm"][
+                                "bytecode"
+                            ]["object"]
+                            compilation_unit.bytecodes_runtime[contract_name] = info["evm"][
+                                "deployedBytecode"
+                            ]["object"]
+                            compilation_unit.srcmaps_init[contract_name] = info["evm"]["bytecode"][
+                                "sourceMap"
+                            ].split(";")
+                            compilation_unit.srcmaps_runtime[contract_name] = info["evm"][
+                                "deployedBytecode"
+                            ]["sourceMap"].split(";")
+                            userdoc = info.get("userdoc", {})
+                            devdoc = info.get("devdoc", {})
+                            natspec = Natspec(userdoc, devdoc)
+                            compilation_unit.natspec[contract_name] = natspec
+
+                if "sources" in targets_json:
+                    for path, info in targets_json["sources"].items():
+                        if skip_filename:
+                            path = convert_filename(
+                                self._target,
+                                relative_to_short,
+                                crytic_compile,
+                                working_dir=hardhat_working_dir,
+                            )
+                        else:
+                            path = convert_filename(
+                                path,
+                                relative_to_short,
+                                crytic_compile,
+                                working_dir=hardhat_working_dir,
+                            )
+                        crytic_compile.filenames.add(path)
+                        compilation_unit.asts[path.absolute] = info["ast"]
 
     @staticmethod
     def is_supported(target: str, **kwargs: str) -> bool:

--- a/crytic_compile/platform/solc.py
+++ b/crytic_compile/platform/solc.py
@@ -88,10 +88,16 @@ def export_to_solc(crytic_compile: "CryticCompile", **kwargs: str) -> List[str]:
     :return:
     """
     # Obtain objects to represent each contract
-
-    paths = []
     export_dir = kwargs.get("export_dir", "crytic-export")
 
+    if len(crytic_compile.compilation_units) == 1:
+        compilation_unit = list(crytic_compile.compilation_units.values())[0]
+        path = export_to_solc_from_compilation_unit(compilation_unit, "combined_solc", export_dir)
+        if path:
+            return [path]
+        return []
+
+    paths = []
     for key, compilation_unit in crytic_compile.compilation_units.items():
         path = export_to_solc_from_compilation_unit(compilation_unit, key, export_dir)
         if path:

--- a/crytic_compile/platform/solc.py
+++ b/crytic_compile/platform/solc.py
@@ -8,6 +8,7 @@ import re
 import subprocess
 from typing import TYPE_CHECKING, Dict, List, Optional, Union
 
+from crytic_compile.compilation_unit import CompilationUnit
 from crytic_compile.compiler.compiler import CompilerVersion
 from crytic_compile.platform.abstract_platform import AbstractPlatform
 from crytic_compile.platform.exceptions import InvalidCompilation
@@ -28,38 +29,33 @@ if TYPE_CHECKING:
 LOGGER = logging.getLogger("CryticCompile")
 
 
-def export_to_solc(crytic_compile: "CryticCompile", **kwargs: str) -> Union[str, None]:
-    """
-    Export the project to the solc format
-
-    :param crytic_compile:
-    :param kwargs:
-    :return:
-    """
-    # Obtain objects to represent each contract
+def export_to_solc_from_compilation_unit(
+    compilation_unit: "CompilationUnit", key: str, export_dir: str
+) -> Optional[str]:
     contracts = dict()
-    for contract_name in crytic_compile.contracts_names:
-        abi = str(crytic_compile.abi(contract_name))
+
+    for contract_name in compilation_unit.contracts_names:
+        abi = str(compilation_unit.abi(contract_name))
         abi = abi.replace("'", '"')
         abi = abi.replace("True", "true")
         abi = abi.replace("False", "false")
         abi = abi.replace(" ", "")
         exported_name = combine_filename_name(
-            crytic_compile.contracts_filenames[contract_name].absolute, contract_name
+            compilation_unit.contracts_filenames[contract_name].absolute, contract_name
         )
         contracts[exported_name] = {
-            "srcmap": ";".join(crytic_compile.srcmap_init(contract_name)),
-            "srcmap-runtime": ";".join(crytic_compile.srcmap_runtime(contract_name)),
+            "srcmap": ";".join(compilation_unit.srcmap_init(contract_name)),
+            "srcmap-runtime": ";".join(compilation_unit.srcmap_runtime(contract_name)),
             "abi": abi,
-            "bin": crytic_compile.bytecode_init(contract_name),
-            "bin-runtime": crytic_compile.bytecode_runtime(contract_name),
-            "userdoc": crytic_compile.natspec[contract_name].userdoc.export(),
-            "devdoc": crytic_compile.natspec[contract_name].devdoc.export(),
+            "bin": compilation_unit.bytecode_init(contract_name),
+            "bin-runtime": compilation_unit.bytecode_runtime(contract_name),
+            "userdoc": compilation_unit.natspec[contract_name].userdoc.export(),
+            "devdoc": compilation_unit.natspec[contract_name].devdoc.export(),
         }
 
     # Create additional informational objects.
-    sources = {filename: {"AST": ast} for (filename, ast) in crytic_compile.asts.items()}
-    source_list = [x.absolute for x in crytic_compile.filenames]
+    sources = {filename: {"AST": ast} for (filename, ast) in compilation_unit.asts.items()}
+    source_list = [x.absolute for x in compilation_unit.crytic_compile.filenames]
 
     # needed for Echidna, see https://github.com/crytic/crytic-compile/issues/112
     first_source_list = list(filter(lambda f: "@" in f, source_list))
@@ -72,16 +68,35 @@ def export_to_solc(crytic_compile: "CryticCompile", **kwargs: str) -> Union[str,
     output = {"sources": sources, "sourceList": source_list, "contracts": contracts}
 
     # If we have an export directory specified, we output the JSON.
-    export_dir = kwargs.get("export_dir", "crytic-export")
     if export_dir:
         if not os.path.exists(export_dir):
             os.makedirs(export_dir)
-        path = os.path.join(export_dir, "combined_solc.json")
+        path = os.path.join(export_dir, f"{key}.json")
 
         with open(path, "w", encoding="utf8") as file_desc:
             json.dump(output, file_desc)
         return path
     return None
+
+
+def export_to_solc(crytic_compile: "CryticCompile", **kwargs: str) -> List[str]:
+    """
+    Export the project to the solc format
+
+    :param crytic_compile:
+    :param kwargs:
+    :return:
+    """
+    # Obtain objects to represent each contract
+
+    paths = []
+    export_dir = kwargs.get("export_dir", "crytic-export")
+
+    for key, compilation_unit in crytic_compile.compilation_units.items():
+        path = export_to_solc_from_compilation_unit(compilation_unit, key, export_dir)
+        if path:
+            paths.append(path)
+    return paths
 
 
 class Solc(AbstractPlatform):
@@ -104,19 +119,20 @@ class Solc(AbstractPlatform):
 
         solc_working_dir = kwargs.get("solc_working_dir", None)
         force_legacy_json = kwargs.get("solc_force_legacy_json", False)
+        compilation_unit = CompilationUnit(crytic_compile, str(self._target))
 
-        targets_json = _get_targets_json(crytic_compile, self._target, **kwargs)
+        targets_json = _get_targets_json(compilation_unit, self._target, **kwargs)
 
         # there have been a couple of changes in solc starting from 0.8.x,
-        if force_legacy_json and _is_at_or_above_minor_version(crytic_compile, 8):
+        if force_legacy_json and _is_at_or_above_minor_version(compilation_unit, 8):
             raise InvalidCompilation("legacy JSON not supported from 0.8.x onwards")
 
-        skip_filename = crytic_compile.compiler_version.version in [
+        skip_filename = compilation_unit.compiler_version.version in [
             f"0.4.{x}" for x in range(0, 10)
         ]
 
         _handle_contracts(
-            targets_json, skip_filename, crytic_compile, self._target, solc_working_dir
+            targets_json, skip_filename, compilation_unit, self._target, solc_working_dir
         )
 
         if "sources" in targets_json:
@@ -133,7 +149,7 @@ class Solc(AbstractPlatform):
                         path, relative_to_short, crytic_compile, working_dir=solc_working_dir
                     )
                 crytic_compile.filenames.add(path)
-                crytic_compile.asts[path.absolute] = info["AST"]
+                compilation_unit.asts[path.absolute] = info["AST"]
 
     @staticmethod
     def is_supported(target: str, **kwargs: str) -> bool:
@@ -163,7 +179,7 @@ class Solc(AbstractPlatform):
         return []
 
 
-def _get_targets_json(crytic_compile: "CryticCompile", target: str, **kwargs):
+def _get_targets_json(compilation_unit: "CompilationUnit", target: str, **kwargs):
     solc = kwargs.get("solc", "solc")
     solc_disable_warnings = kwargs.get("solc_disable_warnings", False)
     solc_arguments = kwargs.get("solc_args", "")
@@ -182,7 +198,7 @@ def _get_targets_json(crytic_compile: "CryticCompile", target: str, **kwargs):
         if isinstance(solcs_path, str):
             solcs_path = solcs_path.split(",")
         return _run_solcs_path(
-            crytic_compile,
+            compilation_unit,
             target,
             solcs_path,
             solc_disable_warnings,
@@ -195,7 +211,7 @@ def _get_targets_json(crytic_compile: "CryticCompile", target: str, **kwargs):
     if solcs_env:
         solcs_env_list = solcs_env.split(",")
         return _run_solcs_env(
-            crytic_compile,
+            compilation_unit,
             target,
             solc,
             solc_disable_warnings,
@@ -207,7 +223,7 @@ def _get_targets_json(crytic_compile: "CryticCompile", target: str, **kwargs):
         )
 
     return _run_solc(
-        crytic_compile,
+        compilation_unit,
         target,
         solc,
         solc_disable_warnings,
@@ -221,12 +237,14 @@ def _get_targets_json(crytic_compile: "CryticCompile", target: str, **kwargs):
 def _handle_contracts(
     targets_json: Dict,
     skip_filename: bool,
-    crytic_compile: "CryticCompile",
+    compilation_unit: "CompilationUnit",
     target: str,
     solc_working_dir: Optional[str],
 ):
-    is_above_0_8 = _is_at_or_above_minor_version(crytic_compile, 8)
+    is_above_0_8 = _is_at_or_above_minor_version(compilation_unit, 8)
+
     if "contracts" in targets_json:
+
         for original_contract_name, info in targets_json["contracts"].items():
             contract_name = extract_name(original_contract_name)
             contract_filename = extract_filename(original_contract_name)
@@ -235,32 +253,32 @@ def _handle_contracts(
                 contract_filename = convert_filename(
                     target,
                     relative_to_short,
-                    crytic_compile,
+                    compilation_unit.crytic_compile,
                     working_dir=solc_working_dir,
                 )
             else:
                 contract_filename = convert_filename(
                     contract_filename,
                     relative_to_short,
-                    crytic_compile,
+                    compilation_unit.crytic_compile,
                     working_dir=solc_working_dir,
                 )
-            crytic_compile.contracts_names.add(contract_name)
-            crytic_compile.contracts_filenames[contract_name] = contract_filename
-            crytic_compile.abis[contract_name] = (
+            compilation_unit.contracts_names.add(contract_name)
+            compilation_unit.contracts_filenames[contract_name] = contract_filename
+            compilation_unit.abis[contract_name] = (
                 json.loads(info["abi"]) if not is_above_0_8 else info["abi"]
             )
-            crytic_compile.bytecodes_init[contract_name] = info["bin"]
-            crytic_compile.bytecodes_runtime[contract_name] = info["bin-runtime"]
-            crytic_compile.srcmaps_init[contract_name] = info["srcmap"].split(";")
-            crytic_compile.srcmaps_runtime[contract_name] = info["srcmap-runtime"].split(";")
+            compilation_unit.bytecodes_init[contract_name] = info["bin"]
+            compilation_unit.bytecodes_runtime[contract_name] = info["bin-runtime"]
+            compilation_unit.srcmaps_init[contract_name] = info["srcmap"].split(";")
+            compilation_unit.srcmaps_runtime[contract_name] = info["srcmap-runtime"].split(";")
             userdoc = json.loads(info.get("userdoc", "{}")) if not is_above_0_8 else info["userdoc"]
             devdoc = json.loads(info.get("devdoc", "{}")) if not is_above_0_8 else info["devdoc"]
             natspec = Natspec(userdoc, devdoc)
-            crytic_compile.natspec[contract_name] = natspec
+            compilation_unit.natspec[contract_name] = natspec
 
 
-def _is_at_or_above_minor_version(crytic_compile: "CryticCompile", version: int) -> bool:
+def _is_at_or_above_minor_version(compilation_unit: "CompilationUnit", version: int) -> bool:
     """
     Checks if the solc version is at or above(=newer) a given minor (0.x.0) version
 
@@ -269,7 +287,7 @@ def _is_at_or_above_minor_version(crytic_compile: "CryticCompile", version: int)
     :return:
 
     """
-    return int(crytic_compile.compiler_version.version.split(".")[1]) >= version
+    return int(compilation_unit.compiler_version.version.split(".")[1]) >= version
 
 
 def get_version(solc: str, env: Dict[str, str]) -> str:
@@ -307,7 +325,7 @@ def is_optimized(solc_arguments: str) -> bool:
 
 # pylint: disable=too-many-arguments,too-many-locals,too-many-branches
 def _run_solc(
-    crytic_compile: "CryticCompile",
+    compilation_unit: "CompilationUnit",
     filename: str,
     solc: str,
     solc_disable_warnings,
@@ -340,11 +358,11 @@ def _run_solc(
     if not filename.endswith(".sol"):
         raise InvalidCompilation("Incorrect file format")
 
-    crytic_compile.compiler_version = CompilerVersion(
+    compilation_unit.compiler_version = CompilerVersion(
         compiler="solc", version=get_version(solc, env), optimized=is_optimized(solc_arguments)
     )
 
-    compiler_version = crytic_compile.compiler_version
+    compiler_version = compilation_unit.compiler_version
     assert compiler_version
     old_04_versions = [f"0.4.{x}" for x in range(0, 12)]
     if compiler_version.version in old_04_versions or compiler_version.version.startswith("0.3"):
@@ -415,7 +433,7 @@ def _run_solc(
 
 # pylint: disable=too-many-arguments
 def _run_solcs_path(
-    crytic_compile,
+    compilation_unit: "CompilationUnit",
     filename,
     solcs_path,
     solc_disable_warnings,
@@ -433,7 +451,7 @@ def _run_solcs_path(
                 continue
             try:
                 targets_json = _run_solc(
-                    crytic_compile,
+                    compilation_unit,
                     filename,
                     solcs_path[guessed_solc],
                     solc_disable_warnings,
@@ -452,7 +470,7 @@ def _run_solcs_path(
         for solc_bin in solc_bins:
             try:
                 targets_json = _run_solc(
-                    crytic_compile,
+                    compilation_unit,
                     filename,
                     solc_bin,
                     solc_disable_warnings,
@@ -475,7 +493,7 @@ def _run_solcs_path(
 
 # pylint: disable=too-many-arguments
 def _run_solcs_env(
-    crytic_compile,
+    compilation_unit: "CompilationUnit",
     filename,
     solc,
     solc_disable_warnings,
@@ -495,7 +513,7 @@ def _run_solcs_env(
         try:
             env["SOLC_VERSION"] = guessed_solc
             targets_json = _run_solc(
-                crytic_compile,
+                compilation_unit,
                 filename,
                 solc,
                 solc_disable_warnings,
@@ -515,7 +533,7 @@ def _run_solcs_env(
             try:
                 env["SOLC_VERSION"] = version_env
                 targets_json = _run_solc(
-                    crytic_compile,
+                    compilation_unit,
                     filename,
                     solc,
                     solc_disable_warnings,


### PR DESCRIPTION
This PR is a breaking change. The `CryticCompile` objects now has a `compilation_units` dictionary, which maps a unique key (str) to a `CompilationUnit` object.

A lot of functions from `CryticCompile` are moved to `CompilationUnit`. This also leads the export functions to generate multiple json files (this will need to be taken into account into Echidna).

For now, only hardhat supports the multi compilation units. I think brownie might support it too (needs investigation)

This PR requires to adapt the following tools:
- [x] Slither
- [x] Manticore
- [x] evm-cfg-builder
- [x] Echidna
- [ ] Oyente

Fix #164.