### PR TITLE
Add vyper source mapping for runtime

### DIFF
--- a/crytic_compile/platform/vyper.py
+++ b/crytic_compile/platform/vyper.py
@@ -62,8 +62,14 @@ class Vyper(AbstractPlatform):
         crytic_compile.abis[contract_name] = info["abi"]
         crytic_compile.bytecodes_init[contract_name] = info["bytecode"].replace("0x", "")
         crytic_compile.bytecodes_runtime[contract_name] = info["bytecode_runtime"].replace("0x", "")
+        # Vyper does not provide the source mapping for the init bytecode
         crytic_compile.srcmaps_init[contract_name] = []
-        crytic_compile.srcmaps_runtime[contract_name] = []
+        # info["source_map"]["pc_pos_map"] contains the source mapping in a simpler format
+        # However pc_pos_map_compressed" seems to follow solc's format, so for convenience
+        # We store the same
+        # TODO: create SourceMapping class, so that srcmaps_runtime would store an class
+        # That will give more flexebility to different compilers
+        crytic_compile.srcmaps_runtime[contract_name] = info["source_map"]["pc_pos_map_compressed"]
 
         crytic_compile.filenames.add(contract_filename)
 


### PR DESCRIPTION
Replace https://github.com/crytic/crytic-compile/pull/170