### PR TITLE
etherscan handle targeted file in multi-file response not being the 1st one

### DIFF
--- a/crytic_compile/platform/etherscan.py
+++ b/crytic_compile/platform/etherscan.py
@@ -121,7 +121,9 @@ def _handle_multiple_files(
         elif path_filename.name == f"{contract_name}.sol":
             if returned_filename.name == path_filename.name:
                 # if there are multiple contracts with the same name as the targeted file, we cannot know which one to pick
-                LOGGER.error("Duplicate contract name in etherscan results, couldn't decide on contract to use")
+                LOGGER.error(
+                    "Duplicate contract name in etherscan results, couldn't decide on contract to use"
+                )
                 raise InvalidCompilation("Duplicate contract name in etherscan results of " + addr)
             returned_filename = path_filename
 

--- a/crytic_compile/platform/etherscan.py
+++ b/crytic_compile/platform/etherscan.py
@@ -114,9 +114,15 @@ def _handle_multiple_files(
         if "contracts" in path_filename.parts and not filename.startswith("@"):
             path_filename = Path(*path_filename.parts[path_filename.parts.index("contracts") :])
 
-        # For now we assume that the targeted file is the first one returned
-        # This work on the initial tests, but might not be true
+        # start by assuming that the targeted file is the first one returned
         if returned_filename is None:
+            returned_filename = path_filename
+        # but if later on a file exists whose name matches the contract name reported by Etherscan, use that
+        elif path_filename.name == f"{contract_name}.sol":
+            if returned_filename.name == path_filename.name:
+                # if there are multiple contracts with the same name as the targeted file, we cannot know which one to pick
+                LOGGER.error("Duplicate contract name in etherscan results, couldn't decide on contract to use")
+                raise InvalidCompilation("Duplicate contract name in etherscan results of " + addr)
             returned_filename = path_filename
 
         path_filename = Path(directory, path_filename)


### PR DESCRIPTION
running `crytic-compile 0xf38ca0cffc53a6b6c62c2be87967fcc13e807751 --export-zip out.zip`
will return a zip whose contents will be:

```json
{
    "compilation_units": {
        "contracts/DInterest.sol": {
            "compiler": {
                "compiler": "solc",
                "version": "0.5.17",
                "optimized": true
            },
            
            ...
```

However, if you look at etherscan than the contract is the `EMAOracle` contract, not the `DInterest` contract.

crytic-compile uses `DInterest` since it is the first contract in the multi-file response from etherscan, `EMAOracle` is item 36 (as can also be seen here: https://etherscan.io/address/0xf38ca0cffc53a6b6c62c2be87967fcc13e807751#code#F36#L1).

The assumption to use the first contract is therefore not always correct. Hence this update will:
- use a contract with an exact name match
- otherwise falls back to the original use-the-first-contract-in-multifile-response

