### PR TITLE
Fix solc_standard_json regression on Windows

### DIFF
--- a/crytic_compile/platform/solc.py
+++ b/crytic_compile/platform/solc.py
@@ -296,12 +296,13 @@ def _is_at_or_above_minor_version(compilation_unit: "CompilationUnit", version: 
     return int(compilation_unit.compiler_version.version.split(".")[1]) >= version
 
 
-def get_version(solc: str, env: Dict[str, str]) -> str:
+def get_version(solc: str, env: Optional[Dict[str, str]]) -> str:
     """
-    Get the compiler version used
+    Obtains the version of the solc executable specified.
 
-    :param solc:
-    :return:
+    :param solc: The solc executable name to invoke.
+    :param env: An optional environment key-value store which can be used when invoking the solc executable.
+    :return: Returns the version of the provided solc executable.
     """
     cmd = [solc, "--version"]
     try:

--- a/crytic_compile/platform/solc_standard_json.py
+++ b/crytic_compile/platform/solc_standard_json.py
@@ -132,7 +132,7 @@ class SolcStandardJson(Solc):
 
         compilation_unit.compiler_version = CompilerVersion(
             compiler="solc",
-            version=get_version(solc, dict()),
+            version=get_version(solc, None),
             optimized=is_optimized(solc_arguments),
         )
 


### PR DESCRIPTION
There's another regression with crytic-compile due to the change in this commit: https://github.com/crytic/crytic-compile/blob/b547d036dcee61fe14bef762e22234f4087e7ee6/crytic_compile/platform/solc_standard_json.py#L135

It invokes `solc --version` but passes a blank `dict` for the `env`. Doing so will cause the following error on Windows:
```
  File "c:\users\x\documents\github\crytic-compile\crytic_compile\platform\solc.py", line 309, in get_version
    with subprocess.Popen(
  File "C:\Python\Python39\lib\subprocess.py", line 947, in __init__
    self._execute_child(args, executable, preexec_fn, close_fds,
  File "C:\Python\Python39\lib\subprocess.py", line 1416, in _execute_child
    hp, ht, pid, tid = _winapi.CreateProcess(executable, args,
OSError: [WinError 87] The parameter is incorrect
```

This PR instead changes the blank dictionary to `None`, which will use the existing `os.environ`. Although disjointed behavior exists between how every compilation platform handles optional `env` variables and the logic should likely be cleaned up as well.

This was not tested on Linux/macOS, although `None` is already used as `env` for other platform invocations and is none problematic so this should be fine.