### PR TITLE
Change get_global_offset_from_line to also take an optional character position

### DIFF
--- a/crytic_compile/crytic_compile.py
+++ b/crytic_compile/crytic_compile.py
@@ -231,7 +231,7 @@ class CryticCompile:
         lines_delimiters[acc] = (len(source_code) + 1, 0)
         self._cached_offset_to_line[file] = lines_delimiters
 
-    def get_line_from_offset(self, file: Filename, offset: int) -> Tuple[int, int]:
+    def get_line_and_character_from_offset(self, file: Filename, offset: int) -> Tuple[int, int]:
         if file not in self._cached_offset_to_line:
             self._get_cached_offset_to_line(file)
 


### PR DESCRIPTION
Currently, crytic-compile has a function to take a source file offset and convert it into line and character position numbers. To reverse this operation, `get_global_offset_from_line` could be used, but it only takes a line number, not a character position number.

This PR adds an optional character position parameter which can be used to specify a position on a line number which we want to obtain a source offset for. 

It also renames `get_global_offset_from_line` to `get_global_offset_from_line_and_character` and `get_line_from_offset` into `get_line_and_character_from_offset` for clarity.