### PR TITLE
Add filenames at the compilation-unit level

### DIFF
--- a/crytic_compile/compilation_unit.py
+++ b/crytic_compile/compilation_unit.py
@@ -42,6 +42,9 @@ class CompilationUnit:
         # Natspec
         self._natspec: Dict[str, Natspec] = {}
 
+        # set containing all the filenames of this compilation unit
+        self._filenames: Set[Filename] = set()
+
         # compiler.compiler
         self._compiler_version: CompilerVersion = CompilerVersion(
             compiler="N/A", version="N/A", optimized=False
@@ -84,6 +87,17 @@ class CompilationUnit:
     # region Filenames
     ###################################################################################
     ###################################################################################
+
+    @property
+    def filenames(self) -> Set[Filename]:
+        """
+        :return: set(naming.Filename)
+        """
+        return self._filenames
+
+    @filenames.setter
+    def filenames(self, all_filenames: Set[Filename]) -> None:
+        self._filenames = all_filenames
 
     @property
     def contracts_filenames(self) -> Dict[str, Filename]:

--- a/crytic_compile/platform/brownie.py
+++ b/crytic_compile/platform/brownie.py
@@ -157,6 +157,7 @@ def _iterate_over_files(
             )
 
             compilation_unit.asts[filename.absolute] = target_loaded["ast"]
+            compilation_unit.filenames.add(filename)
             crytic_compile.filenames.add(filename)
             contract_name = target_loaded["contractName"]
             compilation_unit.contracts_filenames[contract_name] = filename

--- a/crytic_compile/platform/buidler.py
+++ b/crytic_compile/platform/buidler.py
@@ -158,6 +158,7 @@ class Buidler(AbstractPlatform):
                         path = convert_filename(
                             path, relative_to_short, crytic_compile, working_dir=buidler_working_dir
                         )
+                    compilation_unit.filenames.add(path)
                     crytic_compile.filenames.add(path)
                     compilation_unit.asts[path.absolute] = info["ast"]
 

--- a/crytic_compile/platform/dapp.py
+++ b/crytic_compile/platform/dapp.py
@@ -109,6 +109,7 @@ class Dapp(AbstractPlatform):
                 path = convert_filename(
                     path, _relative_to_short, crytic_compile, working_dir=self._target
                 )
+                compilation_unit.filenames.add(path)
                 crytic_compile.filenames.add(path)
                 compilation_unit.asts[path.absolute] = info["ast"]
 

--- a/crytic_compile/platform/embark.py
+++ b/crytic_compile/platform/embark.py
@@ -117,6 +117,7 @@ class Embark(AbstractPlatform):
                     k, _relative_to_short, crytic_compile, working_dir=self._target
                 )
                 compilation_unit.asts[filename.absolute] = ast
+                compilation_unit.filenames.add(filename)
                 crytic_compile.filenames.add(filename)
 
             if not "contracts" in targets_loaded:

--- a/crytic_compile/platform/etherscan.py
+++ b/crytic_compile/platform/etherscan.py
@@ -298,6 +298,7 @@ class Etherscan(AbstractPlatform):
                 path, _relative_to_short, crytic_compile, working_dir=working_dir
             )
             crytic_compile.filenames.add(path)
+            compilation_unit.filenames.add(path)
             compilation_unit.asts[path.absolute] = info["AST"]
 
     @staticmethod

--- a/crytic_compile/platform/hardhat.py
+++ b/crytic_compile/platform/hardhat.py
@@ -160,6 +160,7 @@ class Hardhat(AbstractPlatform):
                                 working_dir=hardhat_working_dir,
                             )
                         crytic_compile.filenames.add(path)
+                        compilation_unit.filenames.add(path)
                         compilation_unit.asts[path.absolute] = info["ast"]
 
     @staticmethod

--- a/crytic_compile/platform/solc.py
+++ b/crytic_compile/platform/solc.py
@@ -56,7 +56,7 @@ def export_to_solc_from_compilation_unit(
 
     # Create additional informational objects.
     sources = {filename: {"AST": ast} for (filename, ast) in compilation_unit.asts.items()}
-    source_list = [x.absolute for x in compilation_unit.crytic_compile.filenames]
+    source_list = [x.absolute for x in compilation_unit.filenames]
 
     # needed for Echidna, see https://github.com/crytic/crytic-compile/issues/112
     first_source_list = list(filter(lambda f: "@" in f, source_list))
@@ -155,6 +155,7 @@ class Solc(AbstractPlatform):
                     path = convert_filename(
                         path, relative_to_short, crytic_compile, working_dir=solc_working_dir
                     )
+                compilation_unit.filenames.add(path)
                 crytic_compile.filenames.add(path)
                 compilation_unit.asts[path.absolute] = info["AST"]
 

--- a/crytic_compile/platform/solc_standard_json.py
+++ b/crytic_compile/platform/solc_standard_json.py
@@ -206,6 +206,7 @@ class SolcStandardJson(Solc):
                         path, relative_to_short, crytic_compile, working_dir=solc_working_dir
                     )
                 crytic_compile.filenames.add(path)
+                compilation_unit.filenames.add(path)
                 compilation_unit.asts[path.absolute] = info["ast"]
 
     def _guessed_tests(self) -> List[str]:

--- a/crytic_compile/platform/truffle.py
+++ b/crytic_compile/platform/truffle.py
@@ -216,7 +216,7 @@ class Truffle(AbstractPlatform):
                 # Since truffle 5.3.14, the filenames start with "project:"
                 # See https://github.com/crytic/crytic-compile/issues/199
                 if filename.startswith("project:"):
-                    filename = "." + filename[len("project:"):]
+                    filename = "." + filename[len("project:") :]
 
                 try:
                     filename = convert_filename(

--- a/crytic_compile/platform/truffle.py
+++ b/crytic_compile/platform/truffle.py
@@ -212,6 +212,12 @@ class Truffle(AbstractPlatform):
                     continue
 
                 filename = target_loaded["ast"]["absolutePath"]
+
+                # Since truffle 5.3.14, the filenames start with "project:"
+                # See https://github.com/crytic/crytic-compile/issues/199
+                if filename.startswith("project:"):
+                    filename = "." + filename[len("project:"):]
+
                 try:
                     filename = convert_filename(
                         filename, _relative_to_short, crytic_compile, working_dir=self._target

--- a/crytic_compile/platform/truffle.py
+++ b/crytic_compile/platform/truffle.py
@@ -230,6 +230,7 @@ class Truffle(AbstractPlatform):
 
                 compilation_unit.asts[filename.absolute] = target_loaded["ast"]
                 crytic_compile.filenames.add(filename)
+                compilation_unit.filenames.add(filename)
                 contract_name = target_loaded["contractName"]
                 compilation_unit.natspec[contract_name] = natspec
                 compilation_unit.contracts_filenames[contract_name] = filename

--- a/crytic_compile/platform/vyper.py
+++ b/crytic_compile/platform/vyper.py
@@ -79,6 +79,7 @@ class Vyper(AbstractPlatform):
         ]
 
         crytic_compile.filenames.add(contract_filename)
+        compilation_unit.filenames.add(contract_filename)
 
         # Natspec not yet handled for vyper
         compilation_unit.natspec[contract_name] = Natspec({}, {})

--- a/crytic_compile/platform/waffle.py
+++ b/crytic_compile/platform/waffle.py
@@ -185,6 +185,7 @@ class Waffle(AbstractPlatform):
 
             compilation_unit.asts[filename.absolute] = target_all["sources"][contract[0]]["AST"]
             crytic_compile.filenames.add(filename)
+            compilation_unit.filenames.add(filename)
             compilation_unit.contracts_filenames[contract_name] = filename
             compilation_unit.contracts_names.add(contract_name)
             compilation_unit.abis[contract_name] = target_loaded["abi"]


### PR DESCRIPTION
Fix #186

Additionally split etherlime main function to reduce its number of
statements