### PR TITLE
Fix incorrect filenames set on standard platforms

### DIFF
--- a/crytic_compile/__main__.py
+++ b/crytic_compile/__main__.py
@@ -170,20 +170,18 @@ def _print_filenames(compilation: "CryticCompile") -> None:
     Args:
         compilation (CryticCompile): CryticCompile project
     """
-    printed_filenames = set()
     for compilation_id, compilation_unit in compilation.compilation_units.items():
         print(
             f"Compilation unit: {compilation_id} ({len(compilation_unit.contracts_names)} files, solc {compilation_unit.compiler_version.version})"
         )
         for contract in compilation_unit.contracts_names:
             filename = compilation_unit.filename_of_contract(contract)
-            unique_id = f"{contract} - {filename} - {compilation_id}"
-            if unique_id not in printed_filenames:
-                print(f"\t{contract} -> \n\tAbsolute: {filename.absolute}")
-                print(f"\t\tRelative: {filename.relative}")
-                print(f"\t\tShort: {filename.short}")
-                print(f"\t\tUsed: {filename.used}")
-                printed_filenames.add(unique_id)
+            print(f"\t{contract} -> \n\tAbsolute: {filename.absolute}")
+        for filename in compilation_unit.filenames:
+            print(f"\t{filename.absolute}")
+            print(f"\t\tRelative: {filename.relative}")
+            print(f"\t\tShort: {filename.short}")
+            print(f"\t\tUsed: {filename.used}")
 
 
 def main() -> None:

--- a/crytic_compile/platform/standard.py
+++ b/crytic_compile/platform/standard.py
@@ -360,10 +360,14 @@ def load_from_compile(crytic_compile: "CryticCompile", loaded_json: Dict) -> Tup
                     crytic_compile.dependencies.add(filename.short)
                     crytic_compile.dependencies.add(filename.used)
             compilation_unit.asts = compilation_unit_json["asts"]
+            compilation_unit.filenames = {
+                _convert_dict_to_filename(filename)
+                for filename in compilation_unit_json["filenames"]
+            }
 
     # Set our filenames
     for compilation_unit in crytic_compile.compilation_units.values():
-        crytic_compile.filenames |= set(compilation_unit.contracts_filenames.values())
+        crytic_compile.filenames |= set(compilation_unit.filenames)
 
     crytic_compile.working_dir = loaded_json["working_dir"]
 


### PR DESCRIPTION
The files without a contract were not properly loaded on the standard platform. This affects only users that were exporting the compilation units to json/zip files, to load them again later.

Additionally this PR improves the output of `-print-filenames`