### PR TITLE
add arbitrum platform support (arbiscan.io)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 crytic_compile.egg-info/
 __pycache__/
 *.pyc
+build/
+dist/

--- a/crytic_compile/platform/etherscan.py
+++ b/crytic_compile/platform/etherscan.py
@@ -44,6 +44,7 @@ SUPPORTED_NETWORK = {
     "tobalaba:": ("-tobalaba.etherscan.io", "tobalaba.etherscan.io"),
     "bsc:": (".bscscan.com", "bscscan.com"),
     "testnet.bsc:": ("-testnet.bscscan.com", "testnet.bscscan.com"),
+    "arbitrum:": (".arbiscan.io", "arbiscan.io"),
 }
 
 


### PR DESCRIPTION
Fix https://github.com/crytic/crytic-compile/issues/213

I compiled slither with this patch, and it successfully fetched contract sources from arbiscan.