### PR TITLE
Add new etherscan-like platforms

### DIFF
--- a/crytic_compile/cryticparser/cryticparser.py
+++ b/crytic_compile/cryticparser/cryticparser.py
@@ -313,6 +313,47 @@ def _init_etherscan(parser: ArgumentParser) -> None:
     )
 
     group_etherscan.add_argument(
+        "--arbiscan-apikey",
+        help="Etherscan API key.",
+        action="store",
+        dest="arbiscan_api_key",
+        default=DEFAULTS_FLAG_IN_CONFIG["etherscan_api_key"],
+    )
+
+    group_etherscan.add_argument(
+        "--polygonscan-apikey",
+        help="Etherscan API key.",
+        action="store",
+        dest="polygonscan_api_key",
+        default=DEFAULTS_FLAG_IN_CONFIG["etherscan_api_key"],
+    )
+
+
+    group_etherscan.add_argument(
+        "--avax-apikey",
+        help="Etherscan API key.",
+        action="store",
+        dest="avax_api_key",
+        default=DEFAULTS_FLAG_IN_CONFIG["etherscan_api_key"],
+    )
+
+    group_etherscan.add_argument(
+        "--ftmscan-apikey",
+        help="Etherscan API key.",
+        action="store",
+        dest="ftmscan_api_key",
+        default=DEFAULTS_FLAG_IN_CONFIG["etherscan_api_key"],
+    )
+
+    group_etherscan.add_argument(
+        "--bscan-apikey",
+        help="Etherscan API key.",
+        action="store",
+        dest="bscan_api_key",
+        default=DEFAULTS_FLAG_IN_CONFIG["etherscan_api_key"],
+    )
+
+    group_etherscan.add_argument(
         "--etherscan-export-directory",
         help="Directory in which to save the analyzed contracts.",
         action="store",

--- a/crytic_compile/cryticparser/cryticparser.py
+++ b/crytic_compile/cryticparser/cryticparser.py
@@ -328,7 +328,6 @@ def _init_etherscan(parser: ArgumentParser) -> None:
         default=DEFAULTS_FLAG_IN_CONFIG["etherscan_api_key"],
     )
 
-
     group_etherscan.add_argument(
         "--avax-apikey",
         help="Etherscan API key.",

--- a/crytic_compile/platform/etherscan.py
+++ b/crytic_compile/platform/etherscan.py
@@ -44,7 +44,12 @@ SUPPORTED_NETWORK = {
     "tobalaba:": ("-tobalaba.etherscan.io", "tobalaba.etherscan.io"),
     "bsc:": (".bscscan.com", "bscscan.com"),
     "testnet.bsc:": ("-testnet.bscscan.com", "testnet.bscscan.com"),
-    "arbitrum:": (".arbiscan.io", "arbiscan.io"),
+    "arbi:": (".arbiscan.io", "arbiscan.io"),
+    "testnet.arbi:": ("-testnet.arbiscan.io", "testnet.arbiscan.io"),
+    "poly:": (".polygonscan.com", "polygonscan.com"),
+    "avax:": (".snowtrace.io", "snowtrace.io"),
+    "testnet.avax:": ("-testnet.snowtrace.io", "testnet.snowtrace.io"),
+    "ftm:": (".ftmscan.com", "ftmscan.com"),
 }
 
 
@@ -220,15 +225,36 @@ class Etherscan(AbstractPlatform):
         only_bytecode = kwargs.get("etherscan_only_bytecode", False)
 
         etherscan_api_key = kwargs.get("etherscan_api_key", None)
+        arbiscan_api_key = kwargs.get("arbiscan_api_key", None)
+        polygonscan_api_key = kwargs.get("polygonscan_api_key", None)
+        avax_api_key = kwargs.get("avax_api_key", None)
+        ftmscan_api_key = kwargs.get("ftmscan_api_key", None)
+        bscan_api_key = kwargs.get("bscan_api_key", None)
+
 
         export_dir = kwargs.get("export_dir", "crytic-export")
         export_dir = os.path.join(
             export_dir, kwargs.get("etherscan_export_dir", "etherscan-contracts")
         )
 
-        if etherscan_api_key:
+        if etherscan_api_key and "etherscan" in etherscan_url:
             etherscan_url += f"&apikey={etherscan_api_key}"
             etherscan_bytecode_url += f"&apikey={etherscan_api_key}"
+        if arbiscan_api_key and "arbiscan" in etherscan_url:
+            etherscan_url += f"&apikey={arbiscan_api_key}"
+            etherscan_bytecode_url += f"&apikey={arbiscan_api_key}"
+        if polygonscan_api_key and "polygonscan" in etherscan_url:
+            etherscan_url += f"&apikey={polygonscan_api_key}"
+            etherscan_bytecode_url += f"&apikey={polygonscan_api_key}"
+        if avax_api_key and "snowtrace" in etherscan_url:
+            etherscan_url += f"&apikey={avax_api_key}"
+            etherscan_bytecode_url += f"&apikey={avax_api_key}"
+        if ftmscan_api_key and "ftmscan" in etherscan_url:
+            etherscan_url += f"&apikey={ftmscan_api_key}"
+            etherscan_bytecode_url += f"&apikey={ftmscan_api_key}"
+        if bscan_api_key and "bscscan" in etherscan_url:
+            etherscan_url += f"&apikey={bscan_api_key}"
+            etherscan_bytecode_url += f"&apikey={bscan_api_key}"
 
         source_code: str = ""
         result: Dict[str, Union[bool, str, int]] = dict()

--- a/crytic_compile/platform/etherscan.py
+++ b/crytic_compile/platform/etherscan.py
@@ -231,7 +231,6 @@ class Etherscan(AbstractPlatform):
         ftmscan_api_key = kwargs.get("ftmscan_api_key", None)
         bscan_api_key = kwargs.get("bscan_api_key", None)
 
-
         export_dir = kwargs.get("export_dir", "crytic-export")
         export_dir = os.path.join(
             export_dir, kwargs.get("etherscan_export_dir", "etherscan-contracts")


### PR DESCRIPTION
- Arbi testnet
- Polygonscan
- Snowtrace (avax)
- Snowtrace tesnet
- Ftm

Additionally:
- Rename arbitrum to arbi
- Add --`apikey` flag for every platform