### PR TITLE
Remove contract name collision on compilation unit restriction

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,7 +32,7 @@ To run them locally:
 - `pylint crytic_compile --rcfile pyproject.toml`
 - `black crytic_compile --config pyproject.toml`
 - `mypy crytic_compile --config mypy.ini`
-- `dargling crytic_compile`
+- `darglint crytic_compile`
 
 
 We use pylint `2.8.2`, black `20.8b1`, mypy `0.812` and dargling `1.8.0`.

--- a/crytic_compile/__main__.py
+++ b/crytic_compile/__main__.py
@@ -174,9 +174,9 @@ def _print_filenames(compilation: "CryticCompile") -> None:
         print(
             f"Compilation unit: {compilation_id} ({len(compilation_unit.contracts_names)} files, solc {compilation_unit.compiler_version.version})"
         )
-        for contract in compilation_unit.contracts_names:
-            filename = compilation_unit.filename_of_contract(contract)
-            print(f"\t{contract} -> \n\tAbsolute: {filename.absolute}")
+        for filename, contracts in compilation_unit.filename_to_contracts.items():
+            for contract in contracts:
+                print(f"\t{contract} -> \n\tAbsolute: {filename.absolute}")
         for filename in compilation_unit.filenames:
             print(f"\t{filename.absolute}")
             print(f"\t\tRelative: {filename.relative}")

--- a/crytic_compile/crytic_compile.py
+++ b/crytic_compile/crytic_compile.py
@@ -191,7 +191,9 @@ class CryticCompile:
                 self._filenames_lookup[file.relative] = file
                 self._filenames_lookup[file.used] = file
         if filename not in self._filenames_lookup:
-            raise ValueError(f"{filename} does not exist in {self._filenames_lookup}")
+            raise ValueError(
+                f"{filename} does not exist in {[f.absolute for f in self._filenames_lookup.values()]}"
+            )
         return self._filenames_lookup[filename]
 
     @property

--- a/crytic_compile/platform/brownie.py
+++ b/crytic_compile/platform/brownie.py
@@ -165,7 +165,7 @@ def _iterate_over_files(
             compilation_unit.filenames.add(filename)
             crytic_compile.filenames.add(filename)
             contract_name = target_loaded["contractName"]
-            compilation_unit.contracts_filenames[contract_name] = filename
+            compilation_unit.filename_to_contracts[filename].add(contract_name)
             compilation_unit.contracts_names.add(contract_name)
             compilation_unit.abis[contract_name] = target_loaded["abi"]
             compilation_unit.bytecodes_init[contract_name] = target_loaded["bytecode"].replace(

--- a/crytic_compile/platform/buidler.py
+++ b/crytic_compile/platform/buidler.py
@@ -125,7 +125,7 @@ class Buidler(AbstractPlatform):
                         )
 
                         compilation_unit.contracts_names.add(contract_name)
-                        compilation_unit.contracts_filenames[contract_name] = contract_filename
+                        compilation_unit.filename_to_contracts[contract_filename].add(contract_name)
 
                         compilation_unit.abis[contract_name] = info["abi"]
                         compilation_unit.bytecodes_init[contract_name] = info["evm"]["bytecode"][

--- a/crytic_compile/platform/dapp.py
+++ b/crytic_compile/platform/dapp.py
@@ -79,7 +79,7 @@ class Dapp(AbstractPlatform):
                             optimized |= metadata["settings"]["optimizer"]["enabled"]
                     contract_name = extract_name(original_contract_name)
                     compilation_unit.contracts_names.add(contract_name)
-                    compilation_unit.contracts_filenames[contract_name] = original_filename
+                    compilation_unit.filename_to_contracts[original_filename].add(contract_name)
 
                     compilation_unit.abis[contract_name] = info["abi"]
                     compilation_unit.bytecodes_init[contract_name] = info["evm"]["bytecode"][

--- a/crytic_compile/platform/embark.py
+++ b/crytic_compile/platform/embark.py
@@ -138,7 +138,7 @@ class Embark(AbstractPlatform):
                     working_dir=self._target,
                 )
 
-                compilation_unit.contracts_filenames[contract_name] = contract_filename
+                compilation_unit.filename_to_contracts[contract_filename].add(contract_name)
                 compilation_unit.contracts_names.add(contract_name)
 
                 if "abi" in info:

--- a/crytic_compile/platform/etherlime.py
+++ b/crytic_compile/platform/etherlime.py
@@ -129,7 +129,7 @@ class Etherlime(AbstractPlatform):
                 compilation_unit.filenames.add(filename)
                 crytic_compile.filenames.add(filename)
                 contract_name = target_loaded["contractName"]
-                compilation_unit.contracts_filenames[contract_name] = filename
+                compilation_unit.filename_to_contracts[filename].add(contract_name)
                 compilation_unit.contracts_names.add(contract_name)
                 compilation_unit.abis[contract_name] = target_loaded["abi"]
                 compilation_unit.bytecodes_init[contract_name] = target_loaded["bytecode"].replace(

--- a/crytic_compile/platform/etherscan.py
+++ b/crytic_compile/platform/etherscan.py
@@ -78,7 +78,7 @@ def _handle_bytecode(crytic_compile: "CryticCompile", target: str, result_b: byt
     compilation_unit = CompilationUnit(crytic_compile, str(target))
 
     compilation_unit.contracts_names.add(contract_name)
-    compilation_unit.contracts_filenames[contract_name] = contract_filename
+    compilation_unit.filename_to_contracts[contract_filename].add(contract_name)
     compilation_unit.abis[contract_name] = {}
     compilation_unit.bytecodes_init[contract_name] = bytecode
     compilation_unit.bytecodes_runtime[contract_name] = ""

--- a/crytic_compile/platform/hardhat.py
+++ b/crytic_compile/platform/hardhat.py
@@ -51,9 +51,11 @@ class Hardhat(AbstractPlatform):
             "ignore_compile", False
         )
 
-        build_directory = Path(kwargs.get("hardhat_artifacts_directory", "artifacts"), "build-info")
+        build_directory = Path(
+            self._target, kwargs.get("hardhat_artifacts_directory", "artifacts"), "build-info"
+        )
 
-        hardhat_working_dir = kwargs.get("hardhat_working_dir", None)
+        hardhat_working_dir = kwargs.get("hardhat_working_dir", self._target)
 
         base_cmd = ["hardhat"]
         if not kwargs.get("npx_disable", False):
@@ -127,7 +129,9 @@ class Hardhat(AbstractPlatform):
                             )
 
                             compilation_unit.contracts_names.add(contract_name)
-                            compilation_unit.contracts_filenames[contract_name] = contract_filename
+                            compilation_unit.filename_to_contracts[contract_filename].add(
+                                contract_name
+                            )
 
                             compilation_unit.abis[contract_name] = info["abi"]
                             compilation_unit.bytecodes_init[contract_name] = info["evm"][

--- a/crytic_compile/platform/solc_standard_json.py
+++ b/crytic_compile/platform/solc_standard_json.py
@@ -171,7 +171,7 @@ class SolcStandardJson(Solc):
                             working_dir=solc_working_dir,
                         )
                     compilation_unit.contracts_names.add(contract_name)
-                    compilation_unit.contracts_filenames[contract_name] = contract_filename
+                    compilation_unit.filename_to_contracts[contract_filename].add(contract_name)
                     compilation_unit.abis[contract_name] = info["abi"]
 
                     userdoc = info.get("userdoc", {})

--- a/crytic_compile/platform/vyper.py
+++ b/crytic_compile/platform/vyper.py
@@ -60,7 +60,7 @@ class Vyper(AbstractPlatform):
         contract_name = Path(target).parts[-1]
 
         compilation_unit.contracts_names.add(contract_name)
-        compilation_unit.contracts_filenames[contract_name] = contract_filename
+        compilation_unit.filename_to_contracts[contract_filename].add(contract_name)
         compilation_unit.abis[contract_name] = info["abi"]
         compilation_unit.bytecodes_init[contract_name] = info["bytecode"].replace("0x", "")
         compilation_unit.bytecodes_runtime[contract_name] = info["bytecode_runtime"].replace(

--- a/crytic_compile/platform/waffle.py
+++ b/crytic_compile/platform/waffle.py
@@ -188,7 +188,7 @@ class Waffle(AbstractPlatform):
             compilation_unit.asts[filename.absolute] = target_all["sources"][contract[0]]["AST"]
             crytic_compile.filenames.add(filename)
             compilation_unit.filenames.add(filename)
-            compilation_unit.contracts_filenames[contract_name] = filename
+            compilation_unit.filename_to_contracts[filename].add(contract_name)
             compilation_unit.contracts_names.add(contract_name)
             compilation_unit.abis[contract_name] = target_loaded["abi"]
 


### PR DESCRIPTION
This PR removes the assumption that a compilation unit will not have multiple contracts with the same name. This PR contains a lot of **breaking changes**

Multiple functions are removed in `CompilationUnit`:
- contracts_filenames
- contracts_absolute_filenames
- filename_of_contract
- absolute_filename_of_contract
- used_filename_of_contract

As far as I can tell these functions were not used.

Additionally, the standard crytic-compile format was changed, and now includes a filename per contract. However, we kept the backward compatibility for artifacts previously generated

Finally, this PR also improves the support for hardhat runs on a directory different from the current directory