### PR TITLE
feat: override target contract retrieved from etherscan

### DIFF
--- a/crytic_compile/cryticparser/cryticparser.py
+++ b/crytic_compile/cryticparser/cryticparser.py
@@ -305,6 +305,13 @@ def _init_etherscan(parser: ArgumentParser) -> None:
     )
 
     group_etherscan.add_argument(
+        "--contract",
+        help="Name of target contract on Etherscan",
+        action="store",
+        dest="contract_name",
+    )
+
+    group_etherscan.add_argument(
         "--etherscan-apikey",
         help="Etherscan API key.",
         action="store",


### PR DESCRIPTION
Closes #215 

When Etherscan provides a different contract than the "main" contract, crytic-compile will return an undesired contract.
Example: https://etherscan.io/address/0x853d955aCEf822Db058eb8505911ED77F175b99e#code
```
crytic-compile 0x853d955aCEf822Db058eb8505911ED77F175b99e 
```
Currently, this will fetch `AccessControl` by default because Etherscan provides `FRAXStablecoin` as the contract name and that does not match with the target contract, `Frax`.

This PR adds a keyword arg to the etherscan platform that allows users to override the returned contract and specify that we want `Frax`.
```
crytic-compile 0x853d955aCEf822Db058eb8505911ED77F175b99e  --contract Frax.sol
```

Note: this will result in failing compilations for similar instances and will require the user to input the contract they want. We can add error messages to handle this case instead of falling back to a library, for instance.