### PR TITLE
Refactor Etherscan and SolcStandardJson + add solc-select support

### DIFF
--- a/crytic_compile/compiler/compiler.py
+++ b/crytic_compile/compiler/compiler.py
@@ -1,6 +1,54 @@
 """Handle the compiler version
 """
+import logging
+from typing import Optional
 
-from collections import namedtuple
+LOGGER = logging.getLogger("CryticCompile")
 
-CompilerVersion = namedtuple("CompilerVersion", ["compiler", "version", "optimized"])
+# pylint: disable=too-few-public-methods
+class CompilerVersion:
+    """
+    Class representing the compiler information
+    """
+
+    def __init__(
+        self,
+        compiler: str,
+        version: Optional[str],
+        optimized: Optional[bool],
+        optimize_runs: Optional[int] = None,
+    ) -> None:
+        """
+        Initialize a compier version object
+
+        Args:
+            compiler (str): compiler (in most of the case use "solc")
+            version (str): compiler version
+            optimized (Optional[bool]): true if optimization are enabled
+            optimize_runs (Optional[int]): optimize runs number
+        """
+        self.compiler: str = compiler
+        self.version: Optional[str] = version
+        self.optimized: Optional[bool] = optimized
+        self.optimize_runs: Optional[int] = optimize_runs
+
+    def look_for_installed_version(self) -> None:
+        """
+        This function queries solc-select to see if the current compiler version is installed
+        And if its not it will install it
+
+        Returns:
+
+        """
+
+        # pylint: disable=import-outside-toplevel
+        try:
+            from solc_select import solc_select
+
+            if self.version not in solc_select.installed_versions():
+                solc_select.install_artifacts([self.version])
+
+        except ImportError:
+            LOGGER.info(
+                'solc-select is not installed.\nRun "pip install solc-select" to enable automatic switch of solc versions'
+            )

--- a/crytic_compile/platform/dapp.py
+++ b/crytic_compile/platform/dapp.py
@@ -11,7 +11,7 @@ import subprocess
 from pathlib import Path
 
 # Cycle dependency
-from typing import TYPE_CHECKING, List
+from typing import TYPE_CHECKING, List, Optional
 
 from crytic_compile.compilation_unit import CompilationUnit
 from crytic_compile.compiler.compiler import CompilerVersion
@@ -63,7 +63,7 @@ class Dapp(AbstractPlatform):
         with open(os.path.join(directory, "dapp.sol.json")) as file_desc:
             targets_json = json.load(file_desc)
 
-            version = None
+            version: Optional[str] = None
             if "version" in targets_json:
                 version = re.findall(r"\d+\.\d+\.\d+", targets_json["version"])[0]
 
@@ -194,7 +194,7 @@ def _get_version(target: str) -> CompilerVersion:
         CompilerVersion: compiler information
     """
     files = glob.glob(target + "/**/*meta.json", recursive=True)
-    version = None
+    version: Optional[str] = None
     optimized = None
     compiler = "solc"
     for file in files:
@@ -203,8 +203,9 @@ def _get_version(target: str) -> CompilerVersion:
                 config = json.load(file_desc)
             if "compiler" in config:
                 if "version" in config["compiler"]:
-                    version = re.findall(r"\d+\.\d+\.\d+", config["compiler"]["version"])
-                    assert version
+                    versions = re.findall(r"\d+\.\d+\.\d+", config["compiler"]["version"])
+                    if versions:
+                        version = versions[0]
             if "settings" in config:
                 if "optimizer" in config["settings"]:
                     if "enabled" in config["settings"]["optimizer"]:

--- a/crytic_compile/platform/solc.py
+++ b/crytic_compile/platform/solc.py
@@ -346,6 +346,7 @@ def _is_at_or_above_minor_version(compilation_unit: "CompilationUnit", version: 
     Returns:
         bool: True if the compilation unit version is above or equal to the provided version
     """
+    assert compilation_unit.compiler_version.version
     return int(compilation_unit.compiler_version.version.split(".")[1]) >= version
 
 
@@ -413,6 +414,7 @@ def _build_options(compiler_version: CompilerVersion, force_legacy_json: bool) -
         + [f"0.7.{x}" for x in range(0, 7)]
         + [f"0.8.{x}" for x in range(0, 10)]
     )
+    assert compiler_version.version
     if compiler_version.version in old_04_versions or compiler_version.version.startswith("0.3"):
         return "abi,ast,bin,bin-runtime,srcmap,srcmap-runtime,userdoc,devdoc"
     if force_legacy_json:

--- a/crytic_compile/platform/solc_standard_json.py
+++ b/crytic_compile/platform/solc_standard_json.py
@@ -23,216 +23,107 @@ if TYPE_CHECKING:
 LOGGER = logging.getLogger("CryticCompile")
 
 
-# Inherits is_dependency/is_supported from Solc
-class SolcStandardJson(Solc):
+def standalone_compile(
+    filenames: List[str], compilation_unit: CompilationUnit, working_dir: Optional[str] = None
+) -> None:
     """
-    Represent the Standard solc Json object
-    """
+    Boilerplate function to run the the standardjson. compilation_unit.compiler_version must be set before calling this function
 
-    NAME = "Solc-json"
-    PROJECT_URL = "https://solidity.readthedocs.io/en/latest/using-the-compiler.html#compiler-input-and-output-json-description"
-    TYPE = Type.SOLC_STANDARD_JSON
-
-    def __init__(self, target: Union[str, dict] = None, **kwargs: str):
-        """Initializes an object which represents solc standard json
-
-        Args:
-            target (Union[str, dict], optional): A string path to a standard json, or a standard json. Defaults to None.
-            **kwargs: optional arguments.
-
-        Raises:
-            ValueError: If invalid json
-        """
-
-        super().__init__(str(target), **kwargs)
-
-        if target is None:
-            self._json: Dict = dict()
-        elif isinstance(target, str):
-            if os.path.isfile(target):
-                with open(target, mode="r", encoding="utf-8") as target_file:
-                    self._json = json.load(target_file)
-            else:
-                self._json = json.loads(target)
-
-        elif isinstance(target, dict):
-            self._json = target
-        else:
-            raise ValueError("Invalid target for solc standard json input.")
-
-        # Set some default values if they are not provided
-        if "language" not in self._json:
-            self._json["language"] = "Solidity"
-        if "sources" not in self._json:
-            self._json["sources"] = {}
-        if "settings" not in self._json:
-            self._json["settings"] = {}
-
-        if "remappings" not in self._json["settings"]:
-            self._json["settings"]["remappings"] = []
-        if "optimizer" not in self._json["settings"]:
-            self._json["settings"]["optimizer"] = {"enabled": False}
-        if "outputSelection" not in self._json["settings"]:
-            self._json["settings"]["outputSelection"] = {
-                "*": {
-                    "*": [
-                        "abi",
-                        "metadata",
-                        "devdoc",
-                        "userdoc",
-                        "evm.bytecode",
-                        "evm.deployedBytecode",
-                    ],
-                    "": ["ast"],
-                }
-            }
-
-    def add_source_file(self, file_path: str) -> None:
-        """Append file
-
-        Args:
-            file_path (str): file to append
-        """
-        self._json["sources"][file_path] = {"urls": [file_path]}
-
-    def add_remapping(self, remapping: str) -> None:
-        """Append our remappings
-
-        Args:
-            remapping (str): remapping to add
-        """
-        self._json["settings"]["remappings"].append(remapping)
-
-    def to_dict(self) -> Dict:
-        """Patch in our desired output types
-
-        Returns:
-            Dict:
-        """
-        return self._json
-
-    # pylint: disable=too-many-locals
-    def compile(self, crytic_compile: "CryticCompile", **kwargs: Any) -> None:
-        """[summary]
-
-        Args:
-            crytic_compile (CryticCompile): Associated CryticCompile object
-            **kwargs: optional arguments. Used: "solc", "solc_disable_warnings", "solc_args", "solc_working_dir",
-                "solc_remaps"
-        """
-
-        solc: str = kwargs.get("solc", "solc")
-        solc_disable_warnings: bool = kwargs.get("solc_disable_warnings", False)
-        solc_arguments: str = kwargs.get("solc_args", "")
-
-        solc_remaps: Optional[Union[str, List[str]]] = kwargs.get("solc_remaps", None)
-        solc_working_dir: Optional[str] = kwargs.get("solc_working_dir", None)
-
-        compilation_unit = CompilationUnit(crytic_compile, "standard_json")
-
+    Example of usage:
+        compilation_unit = CompilationUnit(crytic_compile, name_target)
         compilation_unit.compiler_version = CompilerVersion(
-            compiler="solc",
-            version=get_version(solc, None),
-            optimized=is_optimized(solc_arguments),
+            compiler="solc", version=compiler_version, optimized=optimization_used, optimize_runs=optimize_runs
         )
+        standalone_compile(filenames_to_compile, compilation_unit
 
-        skip_filename = compilation_unit.compiler_version.version in [
-            f"0.4.{x}" for x in range(0, 10)
-        ]
+    Args:
+        filenames (List[str]): list of the files to compile
+        compilation_unit (CompilationUnit): compilation unit object to populate
+        working_dir (Optional[str]): working directory
 
-        # Add all remappings
-        if solc_remaps:
-            if isinstance(solc_remaps, str):
-                solc_remaps = solc_remaps.split(" ")
-            for solc_remap in solc_remaps:
-                self.add_remapping(solc_remap)
+    Returns:
 
-        # Invoke solc
-        targets_json = _run_solc_standard_json(
-            self.to_dict(), solc, solc_disable_warnings=solc_disable_warnings
-        )
+    """
 
-        if "contracts" in targets_json:
-            for file_path, file_contracts in targets_json["contracts"].items():
-                for contract_name, info in file_contracts.items():
-                    # for solc < 0.4.10 we cant retrieve the filename from the ast
-                    if skip_filename:
-                        contract_filename = convert_filename(
-                            self._target,
-                            relative_to_short,
-                            crytic_compile,
-                            working_dir=solc_working_dir,
-                        )
-                    else:
-                        contract_filename = convert_filename(
-                            file_path,
-                            relative_to_short,
-                            crytic_compile,
-                            working_dir=solc_working_dir,
-                        )
-                    compilation_unit.contracts_names.add(contract_name)
-                    compilation_unit.filename_to_contracts[contract_filename].add(contract_name)
-                    compilation_unit.abis[contract_name] = info["abi"]
+    if compilation_unit.compiler_version.version == "N/A":
+        LOGGER.error("The compiler version of the compilation unit must be set")
+        return
 
-                    userdoc = info.get("userdoc", {})
-                    devdoc = info.get("devdoc", {})
-                    natspec = Natspec(userdoc, devdoc)
-                    compilation_unit.natspec[contract_name] = natspec
+    standard_json_dict: Dict = dict()
+    build_standard_json_default(standard_json_dict)
 
-                    compilation_unit.bytecodes_init[contract_name] = info["evm"]["bytecode"][
-                        "object"
-                    ]
-                    compilation_unit.bytecodes_runtime[contract_name] = info["evm"][
-                        "deployedBytecode"
-                    ]["object"]
-                    compilation_unit.srcmaps_init[contract_name] = info["evm"]["bytecode"][
-                        "sourceMap"
-                    ].split(";")
-                    compilation_unit.srcmaps_runtime[contract_name] = info["evm"][
-                        "deployedBytecode"
-                    ]["sourceMap"].split(";")
+    for filename in filenames:
+        add_source_file(standard_json_dict, filename)
 
-        if "sources" in targets_json:
-            for path, info in targets_json["sources"].items():
-                if skip_filename:
-                    path = convert_filename(
-                        self._target,
-                        relative_to_short,
-                        crytic_compile,
-                        working_dir=solc_working_dir,
-                    )
-                else:
-                    path = convert_filename(
-                        path, relative_to_short, crytic_compile, working_dir=solc_working_dir
-                    )
-                crytic_compile.filenames.add(path)
-                compilation_unit.filenames.add(path)
-                compilation_unit.asts[path.absolute] = info["ast"]
+    add_optimization(
+        standard_json_dict,
+        compilation_unit.compiler_version.optimized,
+        compilation_unit.compiler_version.optimize_runs,
+    )
 
-    def _guessed_tests(self) -> List[str]:
-        """Guess the potential unit tests commands
+    targets_json = run_solc_standard_json(
+        standard_json_dict,
+        compiler_version=compilation_unit.compiler_version,
+        solc_disable_warnings=False,
+        working_dir=working_dir,
+    )
 
-        Returns:
-            List[str]: The guessed unit tests commands
-        """
-        return []
+    parse_standard_json_output(targets_json, compilation_unit, solc_working_dir=working_dir)
+
+
+def build_standard_json_default(json_dict: Dict) -> None:
+    """
+    Populate the given json_dict with the default values for the solc standard json input
+    Only write values for which the keys are not existing
+
+    Args:
+        json_dict (Dict): dictionary used for the solc standard input
+
+    Returns:
+
+    """
+    if "language" not in json_dict:
+        json_dict["language"] = "Solidity"
+    if "sources" not in json_dict:
+        json_dict["sources"] = {}
+    if "settings" not in json_dict:
+        json_dict["settings"] = {}
+
+    if "remappings" not in json_dict["settings"]:
+        json_dict["settings"]["remappings"] = []
+    if "optimizer" not in json_dict["settings"]:
+        json_dict["settings"]["optimizer"] = {"enabled": False}
+    if "outputSelection" not in json_dict["settings"]:
+        json_dict["settings"]["outputSelection"] = {
+            "*": {
+                "*": [
+                    "abi",
+                    "metadata",
+                    "devdoc",
+                    "userdoc",
+                    "evm.bytecode",
+                    "evm.deployedBytecode",
+                ],
+                "": ["ast"],
+            }
+        }
 
 
 # pylint: disable=too-many-locals
-def _run_solc_standard_json(
+def run_solc_standard_json(
     solc_input: Dict,
-    solc: str,
+    compiler_version: CompilerVersion,
     solc_disable_warnings: bool = False,
-    working_dir: Optional[Dict] = None,
+    working_dir: Optional[str] = None,
 ) -> Dict:
     """Run the solc standard json compilation.
     Ensure that crytic_compile.compiler_version is set prior calling _run_solc
 
     Args:
         solc_input (Dict): standard json object
-        solc (str): path to the solc binary
+        compiler_version (CompilerVersion): info regarding the compiler
         solc_disable_warnings (bool): True to not print the solc warnings. Defaults to False.
-        working_dir (Optional[Dict], optional): Working directory to run solc. Defaults to None.
+        working_dir (Optional[str], optional): Working directory to run solc. Defaults to None.
 
     Raises:
         InvalidCompilation: If the compilation failed
@@ -240,17 +131,24 @@ def _run_solc_standard_json(
     Returns:
         Dict: Solc json output
     """
-    cmd = [solc, "--standard-json", "--allow-paths", "."]
+    cmd = [compiler_version.compiler, "--standard-json", "--allow-paths", "."]
     additional_kwargs: Dict = {"cwd": working_dir} if working_dir else {}
 
+    env = dict(os.environ)
+    if compiler_version.version:
+        env["SOLC_VERSION"] = compiler_version.version
+
     try:
+
         with subprocess.Popen(
             cmd,
             stdin=subprocess.PIPE,
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
+            env=env,
             **additional_kwargs,
         ) as process:
+
             stdout_b, stderr_b = process.communicate(json.dumps(solc_input).encode("utf-8"))
             stdout, stderr = (
                 stdout_b.decode(),
@@ -288,3 +186,246 @@ def _run_solc_standard_json(
     except json.decoder.JSONDecodeError:
         # pylint: disable=raise-missing-from
         raise InvalidCompilation(f"Invalid solc compilation {stderr}")
+
+
+def add_source_file(json_dict: Dict, file_path: str) -> None:
+    """
+    Add a path to the solc standard json input
+
+    Args:
+        json_dict (Dict): solc standard json input
+        file_path (str): file to add
+
+    Returns:
+
+    """
+    json_dict["sources"][file_path] = {"urls": [file_path]}
+
+
+def add_remapping(json_dict: Dict, remapping: str) -> None:
+    """
+    Add a remapping to the solc standard json input
+
+    Args:
+        json_dict (Dict): solc standard json input
+        remapping (str): remapping
+
+    Returns:
+
+    """
+    json_dict["settings"]["remappings"].append(remapping)
+
+
+def add_optimization(
+    json_dict: Dict, optimize: Optional[bool], optimize_runs: Optional[int]
+) -> None:
+    """
+    Add optimization settings to the solc standard json input
+
+    Args:
+        json_dict (Dict): solc standard json input
+        optimize (bool): true if optimization are enabled
+        optimize_runs (Optional[int]): number of optimize runs
+
+    Returns:
+
+    """
+    if optimize:
+        json_dict["settings"]["optimizer"] = {"enabled": True}
+        if optimize_runs:
+            json_dict["settings"]["optimizer"]["runs"] = optimize_runs
+        return
+    json_dict["settings"]["optimizer"] = {"enabled": False}
+
+
+def parse_standard_json_output(
+    targets_json: Dict, compilation_unit: CompilationUnit, solc_working_dir: Optional[str] = None
+) -> None:
+    """
+    Parse the targets_json output from solc, and populate compilation_unit accordingly
+
+
+    Args:
+        targets_json (Dict): output from solc
+        compilation_unit (CompilationUnit): compilation unit to populate
+        solc_working_dir (Optional[str]): working dir
+
+    Returns:
+
+    """
+
+    skip_filename = compilation_unit.compiler_version.version in [f"0.4.{x}" for x in range(0, 10)]
+
+    if "contracts" in targets_json:
+        for file_path, file_contracts in targets_json["contracts"].items():
+            for contract_name, info in file_contracts.items():
+                # for solc < 0.4.10 we cant retrieve the filename from the ast
+                if skip_filename:
+                    contract_filename = convert_filename(
+                        file_path,
+                        relative_to_short,
+                        compilation_unit.crytic_compile,
+                        working_dir=solc_working_dir,
+                    )
+                else:
+                    contract_filename = convert_filename(
+                        file_path,
+                        relative_to_short,
+                        compilation_unit.crytic_compile,
+                        working_dir=solc_working_dir,
+                    )
+                compilation_unit.contracts_names.add(contract_name)
+                compilation_unit.filename_to_contracts[contract_filename].add(contract_name)
+                compilation_unit.abis[contract_name] = info["abi"]
+
+                userdoc = info.get("userdoc", {})
+                devdoc = info.get("devdoc", {})
+                natspec = Natspec(userdoc, devdoc)
+                compilation_unit.natspec[contract_name] = natspec
+
+                compilation_unit.bytecodes_init[contract_name] = info["evm"]["bytecode"]["object"]
+                compilation_unit.bytecodes_runtime[contract_name] = info["evm"]["deployedBytecode"][
+                    "object"
+                ]
+                compilation_unit.srcmaps_init[contract_name] = info["evm"]["bytecode"][
+                    "sourceMap"
+                ].split(";")
+                compilation_unit.srcmaps_runtime[contract_name] = info["evm"]["deployedBytecode"][
+                    "sourceMap"
+                ].split(";")
+
+    if "sources" in targets_json:
+        for path, info in targets_json["sources"].items():
+            if skip_filename:
+                path = convert_filename(
+                    path,
+                    relative_to_short,
+                    compilation_unit.crytic_compile,
+                    working_dir=solc_working_dir,
+                )
+            else:
+                path = convert_filename(
+                    path,
+                    relative_to_short,
+                    compilation_unit.crytic_compile,
+                    working_dir=solc_working_dir,
+                )
+            compilation_unit.crytic_compile.filenames.add(path)
+            compilation_unit.filenames.add(path)
+
+            compilation_unit.asts[path.absolute] = info.get("ast")
+
+
+# Inherits is_dependency/is_supported from Solc
+class SolcStandardJson(Solc):
+    """
+    Represent the Standard solc Json object
+    """
+
+    NAME = "Solc-json"
+    PROJECT_URL = "https://solidity.readthedocs.io/en/latest/using-the-compiler.html#compiler-input-and-output-json-description"
+    TYPE = Type.SOLC_STANDARD_JSON
+
+    def __init__(self, target: Union[str, dict] = None, **kwargs: str):
+        """Initializes an object which represents solc standard json
+
+        Args:
+            target (Union[str, dict], optional): A string path to a standard json, or a standard json. Defaults to None.
+            **kwargs: optional arguments.
+
+        Raises:
+            ValueError: If invalid json
+        """
+
+        super().__init__(str(target), **kwargs)
+
+        if target is None:
+            self._json: Dict = dict()
+        elif isinstance(target, str):
+            if os.path.isfile(target):
+                with open(target, mode="r", encoding="utf-8") as target_file:
+                    self._json = json.load(target_file)
+            else:
+                self._json = json.loads(target)
+
+        elif isinstance(target, dict):
+            self._json = target
+        else:
+            raise ValueError("Invalid target for solc standard json input.")
+
+        build_standard_json_default(self._json)
+
+    def add_source_file(self, file_path: str) -> None:
+        """Append file
+
+        Args:
+            file_path (str): file to append
+        """
+        add_source_file(self._json, file_path)
+
+    def add_remapping(self, remapping: str) -> None:
+        """Append our remappings
+
+        Args:
+            remapping (str): remapping to add
+        """
+        add_remapping(self._json, remapping)
+
+    def to_dict(self) -> Dict:
+        """Patch in our desired output types
+
+        Returns:
+            Dict:
+        """
+        return self._json
+
+    # pylint: disable=too-many-locals
+    def compile(self, crytic_compile: "CryticCompile", **kwargs: Any) -> None:
+        """[summary]
+
+        Args:
+            crytic_compile (CryticCompile): Associated CryticCompile object
+            **kwargs: optional arguments. Used: "solc", "solc_disable_warnings", "solc_args", "solc_working_dir",
+                "solc_remaps"
+        """
+
+        solc: str = kwargs.get("solc", "solc")
+        solc_disable_warnings: bool = kwargs.get("solc_disable_warnings", False)
+        solc_arguments: str = kwargs.get("solc_args", "")
+
+        solc_remaps: Optional[Union[str, List[str]]] = kwargs.get("solc_remaps", None)
+        solc_working_dir: Optional[str] = kwargs.get("solc_working_dir", None)
+
+        compilation_unit = CompilationUnit(crytic_compile, "standard_json")
+
+        compilation_unit.compiler_version = CompilerVersion(
+            compiler="solc",
+            version=get_version(solc, None),
+            optimized=is_optimized(solc_arguments),
+        )
+
+        # Add all remappings
+        if solc_remaps:
+            if isinstance(solc_remaps, str):
+                solc_remaps = solc_remaps.split(" ")
+            for solc_remap in solc_remaps:
+                self.add_remapping(solc_remap)
+
+        # Invoke solc
+        targets_json = run_solc_standard_json(
+            self.to_dict(),
+            compilation_unit.compiler_version,
+            solc_disable_warnings=solc_disable_warnings,
+        )
+
+        parse_standard_json_output(
+            targets_json, compilation_unit, solc_working_dir=solc_working_dir
+        )
+
+    def _guessed_tests(self) -> List[str]:
+        """Guess the potential unit tests commands
+
+        Returns:
+            List[str]: The guessed unit tests commands
+        """
+        return []


### PR DESCRIPTION
- Use the standard json to improve the support of multi files in etherscan
- Use the contract name as the compilation unit unique ID (fix #215)
- Create standalone functions for the solc standard json
- Create a CompileVersion object instead of a namedtuple
- Add optimize runs in the compiler version - for now this is only supported for etherscan
- For etherscan, detect if solc-select is installed and warn the user if the lib is not installed. Otherwise, install the solc version if it's missing (fix #157)