### PR TITLE
replace invalid unicode characters instead of failing

### DIFF
--- a/crytic_compile/crytic_compile.py
+++ b/crytic_compile/crytic_compile.py
@@ -354,7 +354,9 @@ class CryticCompile:
         if not self._src_content:
             for filename in self.filenames:
                 if filename.absolute not in self._src_content and os.path.isfile(filename.absolute):
-                    with open(filename.absolute, encoding="utf8", newline="") as source_file:
+                    with open(
+                        filename.absolute, encoding="utf8", newline="", errors="replace"
+                    ) as source_file:
                         self._src_content[filename.absolute] = source_file.read()
         return self._src_content
 


### PR DESCRIPTION
This [file](https://github.com/FraxFinance/frax-solidity/blob/master/src/hardhat/contracts/FPI/ABDKMath64x64.sol) throws a unicode error when the file is read due to the copyright sign `Copyright © 2019 by ABDK Consulting.`https://github.com/crytic/crytic-compile/blob/8983395030741580b8ef2fbf05947f000c0a74d0/crytic_compile/crytic_compile.py#L358 

Instead of failing when a character is not unicode, should we replace them?