### PR TITLE
adding support for .yml files in brownie projects

### DIFF
--- a/crytic_compile/platform/brownie.py
+++ b/crytic_compile/platform/brownie.py
@@ -95,7 +95,7 @@ class Brownie(AbstractPlatform):
         # >= 1.1.0: brownie-config.yaml
         return os.path.isfile(os.path.join(target, "brownie-config.json")) or os.path.isfile(
             os.path.join(target, "brownie-config.yaml")
-        )
+        ) or os.path.isfile(os.path.join(target, "brownie-config.yml"))
 
     def is_dependency(self, _path: str) -> bool:
         """Check if the path is a dependency (not supported for brownie)


### PR DESCRIPTION
.yml is also a valid extension for `brownie-config` files, crytic-compile currently fails if a project is using this extension.