### PR TITLE
Strip extra whitespace from solc arguments

### DIFF
--- a/crytic_compile/platform/solc.py
+++ b/crytic_compile/platform/solc.py
@@ -489,7 +489,7 @@ def _run_solc(
         # split() removes the delimiter, so we add it again
         solc_args_ = [("--" + x).split(" ", 1) for x in solc_args if x]
         # Flat the list of list
-        solc_args = [item for sublist in solc_args_ for item in sublist if item]
+        solc_args = [item.strip() for sublist in solc_args_ for item in sublist if item]
         cmd += solc_args
 
     additional_kwargs: Dict = {"cwd": working_dir} if working_dir else {}


### PR DESCRIPTION
This was causing issues with options such as "--foo xyz --bar baz"
as they were being parsed as ["--foo", "xyz ", "--bar", "baz"]
(note the extra space). This becomes problematic when the arguments
are filesystem paths.