### PR TITLE
Solc encoding errors

### DIFF
--- a/crytic_compile/platform/solc.py
+++ b/crytic_compile/platform/solc.py
@@ -520,7 +520,7 @@ def _run_solc(
         # pylint: disable=raise-missing-from
         raise InvalidCompilation(error)
     stdout_, stderr_ = process.communicate()
-    stdout, stderr = (stdout_.decode(), stderr_.decode())  # convert bytestrings to unicode strings
+    stdout, stderr = (stdout_.decode(encoding="utf-8", errors="ignore"), stderr_.decode(encoding="utf-8", errors="ignore"))  # convert bytestrings to unicode strings
 
     if stderr and (not solc_disable_warnings):
         LOGGER.info("Compilation warnings/errors on %s:\n%s", filename, stderr)

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ setup(
     description="Util to facilitate smart contracts compilation.",
     url="https://github.com/crytic/crytic-compile",
     author="Trail of Bits",
-    version="0.2.1",
+    version="0.2.2",
     packages=find_packages(),
     python_requires=">=3.6",
     install_requires=["pysha3>=1.0.2"],


### PR DESCRIPTION
The solidity compiler will warn about the following code, but crytic-compile fails before it logs the compiler warning. Now, users will see the compiler warning of invalid syntax instead of an encoding error.
```
contract C {
    string s = unicode"�";
}
```