### PR TITLE
Improve Windows support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,9 @@ jobs:
     strategy:
       matrix:
         type: ["solc", "truffle", "embark", "etherlime", "brownie", "waffle", "buidler", "hardhat"]
+        exclude:
+          # Currently broken, tries to pull git:// which is blocked by GH
+          - type: embark
     steps:
     - uses: actions/checkout@v1
     - name: Set up Python 3.6

--- a/crytic_compile/platform/archive.py
+++ b/crytic_compile/platform/archive.py
@@ -77,11 +77,16 @@ class Archive(AbstractPlatform):
         # pylint: disable=import-outside-toplevel
         from crytic_compile.crytic_compile import get_platforms
 
-        if isinstance(self._target, str) and os.path.isfile(self._target):
-            with open(self._target, encoding="utf8") as f_target:
-                loaded_json = json.load(f_target)
-        else:
+        try:
+            if isinstance(self._target, str) and os.path.isfile(self._target):
+                with open(self._target, encoding="utf8") as f_target:
+                    loaded_json = json.load(f_target)
+            else:
+                loaded_json = json.loads(self._target)
+        except (OSError, ValueError):
+            # Can happen if the target is a very large string, isfile will throw an exception
             loaded_json = json.loads(self._target)
+
         (underlying_type, unit_tests) = standard.load_from_compile(crytic_compile, loaded_json)
         underlying_type = TypePlatform(underlying_type)
         platforms: List[Type[AbstractPlatform]] = get_platforms()

--- a/crytic_compile/platform/brownie.py
+++ b/crytic_compile/platform/brownie.py
@@ -4,6 +4,7 @@ Brownie platform. https://github.com/iamdefinitelyahuman/brownie
 import json
 import logging
 import os
+import shutil
 import subprocess
 from pathlib import Path
 from typing import TYPE_CHECKING, Dict, List
@@ -54,7 +55,11 @@ class Brownie(AbstractPlatform):
             cmd = base_cmd + ["compile"]
             try:
                 with subprocess.Popen(
-                    cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, cwd=self._target
+                    cmd,
+                    stdout=subprocess.PIPE,
+                    stderr=subprocess.PIPE,
+                    cwd=self._target,
+                    executable=shutil.which(cmd[0]),
                 ) as process:
                     stdout_bytes, stderr_bytes = process.communicate()
                     stdout, stderr = (

--- a/crytic_compile/platform/buidler.py
+++ b/crytic_compile/platform/buidler.py
@@ -4,6 +4,7 @@ Builder platform
 import json
 import logging
 import os
+import shutil
 import subprocess
 from pathlib import Path
 from typing import TYPE_CHECKING, List, Tuple
@@ -70,7 +71,11 @@ class Buidler(AbstractPlatform):
             )
 
             with subprocess.Popen(
-                cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, cwd=self._target
+                cmd,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                cwd=self._target,
+                executable=shutil.which(cmd[0]),
             ) as process:
 
                 stdout_bytes, stderr_bytes = process.communicate()

--- a/crytic_compile/platform/dapp.py
+++ b/crytic_compile/platform/dapp.py
@@ -7,6 +7,7 @@ import json
 import logging
 import os
 import re
+import shutil
 import subprocess
 from pathlib import Path
 
@@ -176,7 +177,11 @@ def _run_dapp(target: str) -> None:
 
     try:
         with subprocess.Popen(
-            cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, cwd=target
+            cmd,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            cwd=target,
+            executable=shutil.which(cmd[0]),
         ) as process:
             _, _ = process.communicate()
     except OSError as error:

--- a/crytic_compile/platform/embark.py
+++ b/crytic_compile/platform/embark.py
@@ -5,6 +5,7 @@ Embark platform. https://github.com/embark-framework/embark
 import json
 import logging
 import os
+import shutil
 import subprocess
 from pathlib import Path
 from typing import TYPE_CHECKING, List
@@ -64,7 +65,9 @@ class Embark(AbstractPlatform):
             if write_embark_json:
                 try:
                     with subprocess.Popen(
-                        ["npm", "install", plugin_name], cwd=self._target
+                        ["npm", "install", plugin_name],
+                        cwd=self._target,
+                        executable=shutil.which("npm"),
                     ) as process:
                         _, stderr = process.communicate()
                         with open(
@@ -91,7 +94,11 @@ class Embark(AbstractPlatform):
                     cmd = ["npx"] + cmd
                 # pylint: disable=consider-using-with
                 process = subprocess.Popen(
-                    cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, cwd=self._target
+                    cmd,
+                    stdout=subprocess.PIPE,
+                    stderr=subprocess.PIPE,
+                    cwd=self._target,
+                    executable=shutil.which(cmd[0]),
                 )
             except OSError as error:
                 # pylint: disable=raise-missing-from

--- a/crytic_compile/platform/etherlime.py
+++ b/crytic_compile/platform/etherlime.py
@@ -7,6 +7,7 @@ import json
 import logging
 import os
 import re
+import shutil
 import subprocess
 from pathlib import Path
 from typing import TYPE_CHECKING, List, Optional, Any
@@ -48,7 +49,11 @@ def _run_etherlime(target: str, npx_disable: bool, compile_arguments: Optional[s
 
     try:
         with subprocess.Popen(
-            cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, cwd=target
+            cmd,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            cwd=target,
+            executable=shutil.which(cmd[0]),
         ) as process:
             stdout_bytes, stderr_bytes = process.communicate()
             stdout, stderr = (

--- a/crytic_compile/platform/hardhat.py
+++ b/crytic_compile/platform/hardhat.py
@@ -4,6 +4,7 @@ Hardhat platform
 import json
 import logging
 import os
+import shutil
 import subprocess
 from pathlib import Path
 from typing import TYPE_CHECKING, List
@@ -70,7 +71,11 @@ class Hardhat(AbstractPlatform):
             )
 
             with subprocess.Popen(
-                cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, cwd=self._target
+                cmd,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                cwd=self._target,
+                executable=shutil.which(cmd[0]),
             ) as process:
 
                 stdout_bytes, stderr_bytes = process.communicate()

--- a/crytic_compile/platform/solc.py
+++ b/crytic_compile/platform/solc.py
@@ -381,7 +381,6 @@ def get_version(solc: str, env: Optional[Dict[str, str]]) -> str:
                 raise InvalidCompilation(f"Solidity version not found: {stdout}")
             return version[0]
     except OSError as error:
-        print("get versions")
         # pylint: disable=raise-missing-from
         raise InvalidCompilation(error)
 
@@ -529,7 +528,6 @@ def _run_solc(
                 executable=shutil.which(cmd[0]),
                 **additional_kwargs,
             )
-        print(cmd)
     except OSError as error:
         # pylint: disable=raise-missing-from
         raise InvalidCompilation(error)

--- a/crytic_compile/platform/solc.py
+++ b/crytic_compile/platform/solc.py
@@ -5,6 +5,7 @@ import json
 import logging
 import os
 import re
+import shutil
 import subprocess
 from pathlib import Path
 from typing import TYPE_CHECKING, Dict, List, Optional, Union, Any
@@ -367,7 +368,11 @@ def get_version(solc: str, env: Optional[Dict[str, str]]) -> str:
     cmd = [solc, "--version"]
     try:
         with subprocess.Popen(
-            cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, env=env
+            cmd,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            env=env,
+            executable=shutil.which(cmd[0]),
         ) as process:
             stdout_bytes, _ = process.communicate()
             stdout = stdout_bytes.decode()  # convert bytestrings to unicode strings
@@ -509,11 +514,20 @@ def _run_solc(
         # pylint: disable=consider-using-with
         if env:
             process = subprocess.Popen(
-                cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, env=env, **additional_kwargs
+                cmd,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                executable=shutil.which(cmd[0]),
+                env=env,
+                **additional_kwargs,
             )
         else:
             process = subprocess.Popen(
-                cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, **additional_kwargs
+                cmd,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                executable=shutil.which(cmd[0]),
+                **additional_kwargs,
             )
         print(cmd)
     except OSError as error:

--- a/crytic_compile/platform/solc_standard_json.py
+++ b/crytic_compile/platform/solc_standard_json.py
@@ -4,6 +4,7 @@ Handle compilation through the standard solc json format
 import json
 import logging
 import os
+import shutil
 import subprocess
 from typing import TYPE_CHECKING, Dict, List, Optional, Union, Any
 
@@ -146,6 +147,7 @@ def run_solc_standard_json(
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
             env=env,
+            executable=shutil.which(cmd[0]),
             **additional_kwargs,
         ) as process:
 

--- a/crytic_compile/platform/truffle.py
+++ b/crytic_compile/platform/truffle.py
@@ -167,7 +167,11 @@ class Truffle(AbstractPlatform):
                 _write_config(Path(self._target), config_used, overwritten_version)
 
             with subprocess.Popen(
-                cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, cwd=self._target
+                cmd,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                cwd=self._target,
+                executable=shutil.which(cmd[0]),
             ) as process:
 
                 stdout_bytes, stderr_bytes = process.communicate()
@@ -368,7 +372,11 @@ def _get_version(truffle_call: List[str], cwd: str) -> Tuple[str, str]:
     cmd = truffle_call + ["version"]
     try:
         with subprocess.Popen(
-            cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, cwd=cwd
+            cmd,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            cwd=cwd,
+            executable=shutil.which(cmd[0]),
         ) as process:
             sstdout, _ = process.communicate()
             ssstdout = sstdout.decode()  # convert bytestrings to unicode strings

--- a/crytic_compile/platform/vyper.py
+++ b/crytic_compile/platform/vyper.py
@@ -3,6 +3,7 @@ Vyper platform
 """
 import json
 import os
+import shutil
 import subprocess
 from pathlib import Path
 from typing import TYPE_CHECKING, Dict, List, Optional
@@ -147,7 +148,12 @@ def _run_vyper(
     additional_kwargs: Dict = {"cwd": working_dir} if working_dir else {}
     try:
         with subprocess.Popen(
-            cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, env=env, **additional_kwargs
+            cmd,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            env=env,
+            executable=shutil.which(cmd[0]),
+            **additional_kwargs,
         ) as process:
             stdout, stderr = process.communicate()
             res = stdout.split(b"\n")
@@ -186,7 +192,12 @@ def _get_vyper_ast(
     additional_kwargs: Dict = {"cwd": working_dir} if working_dir else {}
     try:
         with subprocess.Popen(
-            cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, env=env, **additional_kwargs
+            cmd,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            env=env,
+            executable=shutil.which(cmd[0]),
+            **additional_kwargs,
         ) as process:
             stdout, stderr = process.communicate()
             res = stdout.split(b"\n")

--- a/crytic_compile/platform/waffle.py
+++ b/crytic_compile/platform/waffle.py
@@ -6,6 +6,7 @@ import json
 import logging
 import os
 import re
+import shutil
 import subprocess
 import tempfile
 from pathlib import Path
@@ -151,7 +152,11 @@ class Waffle(AbstractPlatform):
 
                 try:
                     with subprocess.Popen(
-                        cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, cwd=target
+                        cmd,
+                        stdout=subprocess.PIPE,
+                        stderr=subprocess.PIPE,
+                        cwd=target,
+                        executable=shutil.which(cmd[0]),
                     ) as process:
                         stdout, stderr = process.communicate()
                         if stdout:
@@ -323,7 +328,11 @@ def _get_version(compiler: str, cwd: str, config: Optional[Dict] = None) -> str:
         cmd = ["solc", "--version"]
         try:
             with subprocess.Popen(
-                cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, cwd=cwd
+                cmd,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                cwd=cwd,
+                executable=shutil.which(cmd[0]),
             ) as process:
                 stdout_bytes, _ = process.communicate()
                 stdout_txt = stdout_bytes.decode()  # convert bytestrings to unicode strings
@@ -339,7 +348,11 @@ def _get_version(compiler: str, cwd: str, config: Optional[Dict] = None) -> str:
         cmd = ["solcjs", "--version"]
         try:
             with subprocess.Popen(
-                cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, cwd=cwd
+                cmd,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                cwd=cwd,
+                executable=shutil.which(cmd[0]),
             ) as process:
                 stdout_bytes, _ = process.communicate()
                 stdout_txt = stdout_bytes.decode()  # convert bytestrings to unicode strings

--- a/crytic_compile/utils/naming.py
+++ b/crytic_compile/utils/naming.py
@@ -135,5 +135,8 @@ def convert_filename(
     short = relative_to_short(short)
 
     return Filename(
-        absolute=str(absolute), relative=str(relative), short=str(short), used=used_filename
+        absolute=str(absolute),
+        relative=relative.as_posix(),
+        short=short.as_posix(),
+        used=used_filename,
     )

--- a/crytic_compile/utils/npm.py
+++ b/crytic_compile/utils/npm.py
@@ -38,6 +38,6 @@ def get_package_name(target_txt: Union[str, "SolcStandardJson"]) -> Optional[str
                         return None
         return None
 
-    except OSError:
+    except (OSError, ValueError):
         # Can happen if the target is a very large string, is_dir will throw an exception
         return None


### PR DESCRIPTION
This PR aims to improve Windows support on crytic-compile:

* Fix edge cases that break on Windows
* Fix external tool execution on windows (npx, etc.)
* Normalize use of relative paths to be POSIX-style
* Clean up extra leftover prints from when GH Super Linter v4 was introduced (not Windows specific)