### PR TITLE
Update to gh super linter 4.9.2 + linters

### DIFF
--- a/.github/workflows/black.yml
+++ b/.github/workflows/black.yml
@@ -33,7 +33,7 @@ jobs:
           cp pyproject.toml .github/linters
 
       - name: Black
-        uses: docker://github/super-linter:v4
+        uses: github/super-linter/slim@v4.9.2
         if: always()
         env:
           # run linter on everything to catch preexisting problems

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -33,7 +33,7 @@ jobs:
           cp pyproject.toml .github/linters
 
       - name: Lint everything else
-        uses: docker://github/super-linter:v4
+        uses: github/super-linter/slim@v4.9.2
         if: always()
         env:
           # run linter on everything to catch preexisting problems

--- a/.github/workflows/mypy.yml
+++ b/.github/workflows/mypy.yml
@@ -33,7 +33,7 @@ jobs:
           cp mypy.ini .github/linters
 
       - name: Mypy
-        uses: docker://github/super-linter:v4
+        uses: github/super-linter/slim@v4.9.2
         if: always()
         env:
           # run linter on everything to catch preexisting problems

--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -33,7 +33,7 @@ jobs:
           cp pyproject.toml .github/linters
 
       - name: Pylint
-        uses: docker://github/super-linter:v4
+        uses: github/super-linter/slim@v4.9.2
         if: always()
         env:
           # run linter on everything to catch preexisting problems

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,7 +35,7 @@ To run them locally:
 - `darglint crytic_compile`
 
 
-We use pylint `2.12.2`, black `21.10b0`, mypy `0.812` and darglint `1.8.0`.
+We use pylint `2.13.4`, black `22.3.0`, mypy `0.942` and darglint `1.8.0`.
 
 ## Development Environment
 Instructions for installing a development version of crytic-compile can be found in our [wiki](https://github.com/crytic/crytic-compile/wiki/Developer-installation).

--- a/crytic_compile/platform/solc_standard_json.py
+++ b/crytic_compile/platform/solc_standard_json.py
@@ -139,6 +139,7 @@ def run_solc_standard_json(
     if compiler_version.version:
         env["SOLC_VERSION"] = compiler_version.version
 
+    stderr = ""
     try:
 
         with subprocess.Popen(

--- a/crytic_compile/platform/vyper.py
+++ b/crytic_compile/platform/vyper.py
@@ -146,6 +146,7 @@ def _run_vyper(
     cmd = [vyper, filename, "-f", "combined_json"]
 
     additional_kwargs: Dict = {"cwd": working_dir} if working_dir else {}
+    stderr = ""
     try:
         with subprocess.Popen(
             cmd,
@@ -190,6 +191,7 @@ def _get_vyper_ast(
     cmd = [vyper, filename, "-f", "ast"]
 
     additional_kwargs: Dict = {"cwd": working_dir} if working_dir else {}
+    stderr = ""
     try:
         with subprocess.Popen(
             cmd,


### PR DESCRIPTION
This PR cleanup our CI to use a fix version of gh super linter, to avoid
breaking the CI on new super linter release. Additionally it update our linters, the new versions:

- pylint 2.13.4
- black 22.3.0
- mypy 0.942