### PR TITLE
etherscan: make sure the file path is relative

### DIFF
--- a/crytic_compile/platform/etherscan.py
+++ b/crytic_compile/platform/etherscan.py
@@ -151,6 +151,13 @@ def _handle_multiple_files(
         if "contracts" in path_filename.parts and not filename.startswith("@"):
             path_filename = Path(*path_filename.parts[path_filename.parts.index("contracts") :])
 
+        # Convert "absolute" paths such as "/interfaces/IFoo.sol" into relative ones.
+        # This is needed due to the following behavior from pathlib.Path:
+        # > When several absolute paths are given, the last is taken as an anchor
+        # We need to make sure this is relative, so that Path(directory, ...) remains anchored to directory
+        if path_filename.is_absolute():
+            path_filename = Path(*path_filename.parts[1:])
+
         filtered_paths.append(str(path_filename))
         path_filename = Path(directory, path_filename)
 

--- a/scripts/ci_test_etherscan.sh
+++ b/scripts/ci_test_etherscan.sh
@@ -23,3 +23,11 @@ then
     exit 255
 fi
 
+# From crytic/slither#1154
+crytic-compile 0xcfc1E0968CA08aEe88CbF664D4A1f8B881d90f37 --compile-remove-metadata --etherscan-apikey "$GITHUB_ETHERSCAN"
+
+if [ $? -ne 0 ]
+then
+    echo "Etherscan test failed"
+    exit 255
+fi


### PR DESCRIPTION
If the file path is absolute, crytic-compile may end up trying to write
outside of the expected directory due to the behavior or pathlib.Path

Fixes: crytic/slither#1154