### PR TITLE
Adding foundry type to __str__ function

### DIFF
--- a/crytic_compile/platform/types.py
+++ b/crytic_compile/platform/types.py
@@ -63,4 +63,6 @@ class Type(IntEnum):
             return "Builder"
         if self == Type.BROWNIE:
             return "Browner"
+        if self == Type.FOUNDRY:
+            return "Foundry"
         raise ValueError


### PR DESCRIPTION
Looks like this might have been missed when adding foundry support in this PR (https://github.com/crytic/crytic-compile/pull/251)

Was getting the following error when running: `slither . --compile-force-framework foundry --print human-summary`

```
Traceback (most recent call last):
  File "/opt/hostedtoolcache/Python/3.10.5/x64/lib/python3.10/site-packages/slither/__main__.py", line 744, in main_impl
    ) = process_all(filename, args, detector_classes, printer_classes)
  File "/opt/hostedtoolcache/Python/3.10.5/x64/lib/python3.10/site-packages/slither/__main__.py", line 87, in process_all
    ) = process_single(compilation, args, detector_classes, printer_classes)
  File "/opt/hostedtoolcache/Python/3.10.5/x64/lib/python3.10/site-packages/slither/__main__.py", line 72, in process_single
    return _process(slither, detector_classes, printer_classes)
  File "/opt/hostedtoolcache/Python/3.10.5/x64/lib/python3.10/site-packages/slither/__main__.py", line 119, in _process
    printer_results = slither.run_printers()
  File "/opt/hostedtoolcache/Python/3.10.5/x64/lib/python3.10/site-packages/slither/slither.py", line 211, in run_printers
    return [p.output(self._crytic_compile.target).data for p in self._printers]
  File "/opt/hostedtoolcache/Python/3.10.5/x64/lib/python3.10/site-packages/slither/slither.py", line 211, in <listcomp>
    return [p.output(self._crytic_compile.target).data for p in self._printers]
  File "/opt/hostedtoolcache/Python/3.10.5/x64/lib/python3.10/site-packages/slither/printers/summary/human_summary.py", line 302, in output
    txt += self._compilation_type()
  File "/opt/hostedtoolcache/Python/3.10.5/x64/lib/python3.10/site-packages/slither/printers/summary/human_summary.py", line 203, in _compilation_type
    return f"Compiled with {str(self.slither.crytic_compile.type)}\n"
  File "/opt/hostedtoolcache/Python/3.10.5/x64/lib/python3.10/site-packages/crytic_compile/platform/types.py", line 66, in __str__
    raise ValueError
ValueError
None
Error in .
Traceback (most recent call last):
  File "/opt/hostedtoolcache/Python/3.10.5/x64/lib/python3.10/site-packages/slither/__main__.py", line 744, in main_impl
    ) = process_all(filename, args, detector_classes, printer_classes)
  File "/opt/hostedtoolcache/Python/3.10.5/x64/lib/python3.10/site-packages/slither/__main__.py", line 87, in process_all
    ) = process_single(compilation, args, detector_classes, printer_classes)
  File "/opt/hostedtoolcache/Python/3.10.5/x64/lib/python3.10/site-packages/slither/__main__.py", line 72, in process_single
    return _process(slither, detector_classes, printer_classes)
  File "/opt/hostedtoolcache/Python/3.10.5/x64/lib/python3.10/site-packages/slither/__main__.py", line 119, in _process
    printer_results = slither.run_printers()
  File "/opt/hostedtoolcache/Python/3.10.5/x64/lib/python3.10/site-packages/slither/slither.py", line 211, in run_printers
    return [p.output(self._crytic_compile.target).data for p in self._printers]
  File "/opt/hostedtoolcache/Python/3.10.5/x64/lib/python3.10/site-packages/slither/slither.py", line 211, in <listcomp>
    return [p.output(self._crytic_compile.target).data for p in self._printers]
  File "/opt/hostedtoolcache/Python/3.10.5/x64/lib/python3.10/site-packages/slither/printers/summary/human_summary.py", line 302, in output
    txt += self._compilation_type()
  File "/opt/hostedtoolcache/Python/3.10.5/x64/lib/python3.10/site-packages/slither/printers/summary/human_summary.py", line 203, in _compilation_type
    return f"Compiled with {str(self.slither.crytic_compile.type)}\n"
  File "/opt/hostedtoolcache/Python/3.10.5/x64/lib/python3.10/site-packages/crytic_compile/platform/types.py", line 66, in __str__
    raise ValueError
ValueError
```