### PR TITLE
ci: forge: fix failing test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,7 @@ jobs:
   tests:
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
         os: ["ubuntu-latest", "windows-2022"]
         type: ["brownie", "buidler", "dapp", "embark", "etherlime", "hardhat", "solc", "truffle", "waffle", "foundry"]

--- a/scripts/ci_test_foundry.sh
+++ b/scripts/ci_test_foundry.sh
@@ -9,6 +9,10 @@ curl -L https://foundry.paradigm.xyz | bash
 export PATH=$PATH:/home/runner/.foundry/bin
 foundryup
 
+# The foundry init process makes a temporary local git repo and needs certain values to be set
+git config --global user.email "ci@trailofbits.com"
+git config --global user.name "CI User"
+
 mkdir forge_test
 cd forge_test || exit 255
 forge init


### PR DESCRIPTION
This resolves the Foundry test failures by adding git configuration values.