### PR TITLE
Make sourceMap optional for Foundry projects

### DIFF
--- a/crytic_compile/platform/foundry.py
+++ b/crytic_compile/platform/foundry.py
@@ -142,10 +142,10 @@ class Foundry(AbstractPlatform):
                 ]["object"].replace("0x", "")
                 compilation_unit.srcmaps_init[contract_name] = target_loaded["bytecode"][
                     "sourceMap"
-                ].split(";")
+                ].split(";") if target_loaded["bytecode"].get("sourceMap") else []
                 compilation_unit.srcmaps_runtime[contract_name] = target_loaded["deployedBytecode"][
                     "sourceMap"
-                ].split(";")
+                ].split(";") if target_loaded["deployedBytecode"].get("sourceMap") else []
 
         version, optimized, runs = _get_config_info(self._target)
 


### PR DESCRIPTION
Fixes https://github.com/crytic/crytic-compile/issues/275 and https://github.com/crytic/crytic-compile/issues/281