### PR TITLE
Fix foundry in the CI

### DIFF
--- a/scripts/ci_test_foundry.sh
+++ b/scripts/ci_test_foundry.sh
@@ -5,6 +5,9 @@
 
 cd /tmp || exit 255
 
+git config --global user.email "you@example.com"
+git config --global user.name "Your Name"
+
 curl -L https://foundry.paradigm.xyz | bash
 export PATH=$PATH:/home/runner/.foundry/bin
 foundryup


### PR DESCRIPTION
It looks like that running `forge init` requires now to have git setup?