### PR TITLE
feat: Add Mumbai (Polygon testnet) to SUPPORTED_NETWORKS

### DIFF
--- a/crytic_compile/cryticparser/cryticparser.py
+++ b/crytic_compile/cryticparser/cryticparser.py
@@ -329,6 +329,14 @@ def _init_etherscan(parser: ArgumentParser) -> None:
     )
 
     group_etherscan.add_argument(
+        "--test-polygonscan-apikey",
+        help="Etherscan API key.",
+        action="store",
+        dest="test_polygonscan_api_key",
+        default=DEFAULTS_FLAG_IN_CONFIG["etherscan_api_key"],
+    )
+
+    group_etherscan.add_argument(
         "--avax-apikey",
         help="Etherscan API key.",
         action="store",

--- a/crytic_compile/platform/etherscan.py
+++ b/crytic_compile/platform/etherscan.py
@@ -45,6 +45,7 @@ SUPPORTED_NETWORK = {
     "arbi:": (".arbiscan.io", "arbiscan.io"),
     "testnet.arbi:": ("-testnet.arbiscan.io", "testnet.arbiscan.io"),
     "poly:": (".polygonscan.com", "polygonscan.com"),
+    "mumbai:": (".mumbai.polygonscan.com", "mumbai.polygonscan.com"),
     "avax:": (".snowtrace.io", "snowtrace.io"),
     "testnet.avax:": ("-testnet.snowtrace.io", "testnet.snowtrace.io"),
     "ftm:": (".ftmscan.com", "ftmscan.com"),

--- a/crytic_compile/platform/etherscan.py
+++ b/crytic_compile/platform/etherscan.py
@@ -45,7 +45,7 @@ SUPPORTED_NETWORK = {
     "arbi:": (".arbiscan.io", "arbiscan.io"),
     "testnet.arbi:": ("-testnet.arbiscan.io", "testnet.arbiscan.io"),
     "poly:": (".polygonscan.com", "polygonscan.com"),
-    "mumbai:": ("-mumbai.polygonscan.com", "mumbai.polygonscan.com"),
+    "mumbai:": ("-testnet.polygonscan.com", "testnet.polygonscan.com"),
     "avax:": (".snowtrace.io", "snowtrace.io"),
     "testnet.avax:": ("-testnet.snowtrace.io", "testnet.snowtrace.io"),
     "ftm:": (".ftmscan.com", "ftmscan.com"),

--- a/crytic_compile/platform/etherscan.py
+++ b/crytic_compile/platform/etherscan.py
@@ -257,6 +257,8 @@ class Etherscan(AbstractPlatform):
         contract_name: str = ""
 
         if not only_bytecode:
+            if "polygon" in etherscan_url:
+                etherscan_url = urllib.request.Request(etherscan_url,headers={"User-Agent": "Mozilla/5.0"})
             with urllib.request.urlopen(etherscan_url) as response:
                 html = response.read()
 

--- a/crytic_compile/platform/etherscan.py
+++ b/crytic_compile/platform/etherscan.py
@@ -45,7 +45,7 @@ SUPPORTED_NETWORK = {
     "arbi:": (".arbiscan.io", "arbiscan.io"),
     "testnet.arbi:": ("-testnet.arbiscan.io", "testnet.arbiscan.io"),
     "poly:": (".polygonscan.com", "polygonscan.com"),
-    "mumbai:": (".mumbai.polygonscan.com", "mumbai.polygonscan.com"),
+    "mumbai:": ("-mumbai.polygonscan.com", "mumbai.polygonscan.com"),
     "avax:": (".snowtrace.io", "snowtrace.io"),
     "testnet.avax:": ("-testnet.snowtrace.io", "testnet.snowtrace.io"),
     "ftm:": (".ftmscan.com", "ftmscan.com"),

--- a/crytic_compile/platform/etherscan.py
+++ b/crytic_compile/platform/etherscan.py
@@ -258,9 +258,13 @@ class Etherscan(AbstractPlatform):
 
         if not only_bytecode:
             if "polygon" in etherscan_url:
-                etherscan_url = urllib.request.Request(etherscan_url,headers={"User-Agent": "Mozilla/5.0"})
-            with urllib.request.urlopen(etherscan_url) as response:
-                html = response.read()
+                # build object with headers, then send request
+                new_etherscan_url = urllib.request.Request(etherscan_url,headers={"User-Agent": "Mozilla/5.0"})
+                with urllib.request.urlopen(new_etherscan_url) as response:
+                    html = response.read()
+            else:
+                with urllib.request.urlopen(etherscan_url) as response:
+                    html = response.read()
 
             info = json.loads(html)
 

--- a/crytic_compile/platform/etherscan.py
+++ b/crytic_compile/platform/etherscan.py
@@ -216,6 +216,7 @@ class Etherscan(AbstractPlatform):
         etherscan_api_key = kwargs.get("etherscan_api_key", None)
         arbiscan_api_key = kwargs.get("arbiscan_api_key", None)
         polygonscan_api_key = kwargs.get("polygonscan_api_key", None)
+        test_polygonscan_api_key = kwargs.get("test_polygonscan_api_key", None)
         avax_api_key = kwargs.get("avax_api_key", None)
         ftmscan_api_key = kwargs.get("ftmscan_api_key", None)
         bscan_api_key = kwargs.get("bscan_api_key", None)
@@ -235,6 +236,9 @@ class Etherscan(AbstractPlatform):
         if polygonscan_api_key and "polygonscan" in etherscan_url:
             etherscan_url += f"&apikey={polygonscan_api_key}"
             etherscan_bytecode_url += f"&apikey={polygonscan_api_key}"
+        if test_polygonscan_api_key and "polygonscan" in etherscan_url:
+            etherscan_url += f"&apikey={test_polygonscan_api_key}"
+            etherscan_bytecode_url += f"&apikey={test_polygonscan_api_key}"
         if avax_api_key and "snowtrace" in etherscan_url:
             etherscan_url += f"&apikey={avax_api_key}"
             etherscan_bytecode_url += f"&apikey={avax_api_key}"


### PR DESCRIPTION
## Description
This adds testnet functionality for the Polygon chain. Excuse the poor naming for the commit messages, was using this branch for testing purposes.

I discovered that scanning won't work on the testnet unless Python makes the request as if it were a browser. I added a case to check if the URL contained `polygon` and to build a request object if found. 

This is posted as a draft to see if [this plan](https://github.com/crytic/crytic-compile/pull/232#issuecomment-1067111180) was still on the table as well as if it's necessary to clean up the commit messages. Also, I tested some adhoc Etherscan contracts to verify if other networks were affected, however, full testing will still need to occur. 
