### PR TITLE
foundry: ignore `<file>.metadata.json` and other such artifacts

### DIFF
--- a/crytic_compile/platform/foundry.py
+++ b/crytic_compile/platform/foundry.py
@@ -71,6 +71,10 @@ class Foundry(AbstractPlatform):
                 "--force",
             ]
 
+            # disable extra_output_files via environment variable
+            # it takes precedence over config entries
+            env = dict(os.environ, FOUNDRY_EXTRA_OUTPUT_FILES="[]")
+
             LOGGER.info(
                 "'%s' running",
                 " ".join(cmd),
@@ -82,6 +86,7 @@ class Foundry(AbstractPlatform):
                 stderr=subprocess.PIPE,
                 cwd=self._target,
                 executable=shutil.which(cmd[0]),
+                env=env,
             ) as process:
 
                 stdout_bytes, stderr_bytes = process.communicate()
@@ -94,7 +99,7 @@ class Foundry(AbstractPlatform):
                 if stderr:
                     LOGGER.error(stderr)
 
-        filenames = list(Path(self._target, out_directory).rglob("*.json"))
+        filenames = set(Path(self._target, out_directory).rglob("*.json"))
 
         # foundry only support solc for now
         compiler = "solc"

--- a/scripts/ci_test_foundry.sh
+++ b/scripts/ci_test_foundry.sh
@@ -17,9 +17,24 @@ mkdir forge_test
 cd forge_test || exit 255
 forge init
 
+# base test: just a "forge init" project
+
 crytic-compile .
 if [ $? -ne 0 ]
 then
-    echo "foundry test failed"
+    echo "foundry base test failed"
+    exit 255
+fi
+
+
+# extra files test: "forge init" but with extra_output_files enabled (issue #296)
+forge clean
+echo >> foundry.toml # missing newline at the end of template
+echo 'extra_output_files = ["metadata", "abi"]' >> foundry.toml
+
+crytic-compile .
+if [ $? -ne 0 ]
+then
+    echo "foundry extra files test failed"
     exit 255
 fi


### PR DESCRIPTION
These get generated when `extra_output_files` in the foundry config file  contains `metadata`, `abi` or similar extra values.

Fixes #296 