### PR TITLE
Add custom hardhat `node_modules` directory setting

### DIFF
--- a/crytic_compile/cryticparser/cryticparser.py
+++ b/crytic_compile/cryticparser/cryticparser.py
@@ -456,6 +456,13 @@ def _init_hardhat(parser: ArgumentParser) -> None:
         default=DEFAULTS_FLAG_IN_CONFIG["hardhat_artifacts_directory"],
     )
 
+    group_hardhat.add_argument(
+        "--hardhat-node-modules-directory",
+        help="Use an alternative node_modules directory (default ./node_modules)",
+        action="store",
+        dest="hardhat_node_modules_directory",
+        default=DEFAULTS_FLAG_IN_CONFIG["hardhat_node_modules_directory"],
+    )
 
 def _init_foundry(parser: ArgumentParser) -> None:
     """Init foundry arguments

--- a/crytic_compile/cryticparser/defaults.py
+++ b/crytic_compile/cryticparser/defaults.py
@@ -42,6 +42,7 @@ DEFAULTS_FLAG_IN_CONFIG = {
     "hardhat_ignore_compile": False,
     "hardhat_cache_directory": "cache",
     "hardhat_artifacts_directory": "artifacts",
+    "hardhat_node_modules_directory": None,
     "foundry_ignore_compile": False,
     "foundry_out_directory": "out",
     "export_dir": "crytic-export",

--- a/crytic_compile/platform/hardhat.py
+++ b/crytic_compile/platform/hardhat.py
@@ -57,6 +57,7 @@ class Hardhat(AbstractPlatform):
         )
 
         hardhat_working_dir = kwargs.get("hardhat_working_dir", self._target)
+        node_modules_dir = kwargs.get("hardhat_node_modules_directory", None)
 
         base_cmd = ["hardhat"]
         if not kwargs.get("npx_disable", False):
@@ -131,6 +132,7 @@ class Hardhat(AbstractPlatform):
                                 relative_to_short,
                                 crytic_compile,
                                 working_dir=hardhat_working_dir,
+                                node_modules_dir=node_modules_dir
                             )
 
                             compilation_unit.contracts_names.add(contract_name)
@@ -164,6 +166,7 @@ class Hardhat(AbstractPlatform):
                                 relative_to_short,
                                 crytic_compile,
                                 working_dir=hardhat_working_dir,
+                                node_modules_dir=node_modules_dir
                             )
                         else:
                             path = convert_filename(
@@ -171,6 +174,7 @@ class Hardhat(AbstractPlatform):
                                 relative_to_short,
                                 crytic_compile,
                                 working_dir=hardhat_working_dir,
+                                node_modules_dir=node_modules_dir
                             )
                         crytic_compile.filenames.add(path)
                         compilation_unit.filenames.add(path)

--- a/crytic_compile/utils/naming.py
+++ b/crytic_compile/utils/naming.py
@@ -65,6 +65,7 @@ def convert_filename(
     relative_to_short: Callable[[Path], Path],
     crytic_compile: "CryticCompile",
     working_dir: Optional[Union[str, Path]] = None,
+    node_modules_dir: Optional[Union[str, Path]] = None
 ) -> Filename:
     """Convert a filename to CryticCompile Filename object.
     The used_filename can be absolute, relative, or missing node_modules/contracts directory
@@ -101,14 +102,19 @@ def convert_filename(
         else:
             cwd = Path.cwd().joinpath(Path(working_dir)).resolve()
 
+    if node_modules_dir is None:
+        node_modules_dir = cwd.joinpath(Path("node_modules"))
+    else:
+        node_modules_dir = Path(node_modules_dir)
+
     if crytic_compile.package_name:
         try:
             filename = filename.relative_to(Path(crytic_compile.package_name))
         except ValueError:
             pass
     if not filename.exists():
-        if cwd.joinpath(Path("node_modules"), filename).exists():
-            filename = cwd.joinpath("node_modules", filename)
+        if node_modules_dir.joinpath(filename).exists():
+            filename = node_modules_dir.joinpath(filename)
         elif cwd.joinpath(Path("contracts"), filename).exists():
             filename = cwd.joinpath("contracts", filename)
         elif working_dir.joinpath(filename).exists():


### PR DESCRIPTION
This PR would allow using `crytic-compile` / `slither` for hardhat monorepos, where `node_modules` is usually at the repository root. In the current state this is not possible, since `node_modules` is only searched for inside the target directory.

See #279 for reference.

These changes would be enough for our use case (see https://github.com/balancer-labs/balancer-v2-monorepo/issues/1941) since we only use `hardhat`. I am open to feedback and / or giving a hand implementing this for other platforms if needed, but otherwise having this change in would be great.

Thanks for the review and for your time in advance!