### PR TITLE
fix optimizations not applied in solc-standard-json mode

### DIFF
--- a/crytic_compile/platform/solc_standard_json.py
+++ b/crytic_compile/platform/solc_standard_json.py
@@ -407,6 +407,12 @@ class SolcStandardJson(Solc):
             optimized=is_optimized(solc_arguments),
         )
 
+        add_optimization(
+            self._json,
+            compilation_unit.compiler_version.optimized,
+            compilation_unit.compiler_version.optimize_runs,
+        )
+
         # Add all remappings
         if solc_remaps:
             if isinstance(solc_remaps, str):


### PR DESCRIPTION
optimization options are applied when using the etherscan way but they don't apply in case we fetch the source code manually and run crytic-compile on it. By appending the optimization to the input json, they are now applied as for the etherscan platform.

As you can see, it works with etherscan thanks to that line https://github.com/crytic/crytic-compile/blob/1ca05b8c5a39c60cca20d2014cc0d35e15f54a3e/crytic_compile/platform/solc_standard_json.py#L59 which was missing in the case of standard-json and that I'm adding back with this PR.