### PR TITLE
Auto-clean projects before compiling

### DIFF
--- a/crytic_compile/crytic_compile.py
+++ b/crytic_compile/crytic_compile.py
@@ -545,6 +545,8 @@ class CryticCompile:
             self._run_custom_build(custom_build)
 
         else:
+            if not kwargs.get("skip_clean", False) and not kwargs.get("ignore_compile", False):
+                self._platform.clean(**kwargs)
             self._platform.compile(self, **kwargs)
 
         remove_metadata = kwargs.get("compile_remove_metadata", False)

--- a/crytic_compile/platform/abstract_platform.py
+++ b/crytic_compile/platform/abstract_platform.py
@@ -119,6 +119,15 @@ class AbstractPlatform(metaclass=abc.ABCMeta):
         """
         return
 
+    @abc.abstractmethod
+    def clean(self, **kwargs: str) -> None:
+        """Clean compilation artifacts
+
+        Args:
+            **kwargs: optional arguments.
+        """
+        return
+
     @staticmethod
     @abc.abstractmethod
     def is_supported(target: str, **kwargs: str) -> bool:

--- a/crytic_compile/platform/archive.py
+++ b/crytic_compile/platform/archive.py
@@ -71,7 +71,7 @@ class Archive(AbstractPlatform):
         """Run the compilation
 
         Args:
-            crytic_compile (CryticCompile): asscoiated CryticCompile object
+            crytic_compile (CryticCompile): associated CryticCompile object
             **_kwargs: unused
         """
         # pylint: disable=import-outside-toplevel
@@ -96,6 +96,9 @@ class Archive(AbstractPlatform):
         self._target = "tmp.zip"
 
         crytic_compile.src_content = loaded_json["source_content"]
+
+    def clean(self, **_kwargs: str) -> None:
+        pass
 
     @staticmethod
     def is_supported(target: str, **kwargs: str) -> bool:

--- a/crytic_compile/platform/brownie.py
+++ b/crytic_compile/platform/brownie.py
@@ -82,6 +82,10 @@ class Brownie(AbstractPlatform):
 
         _iterate_over_files(crytic_compile, Path(self._target), filenames)
 
+    def clean(self, **_kwargs: str) -> None:
+        # brownie does not offer a way to clean a project
+        pass
+
     @staticmethod
     def is_supported(target: str, **kwargs: str) -> bool:
         """Check if the target is a brownie project

--- a/crytic_compile/platform/buidler.py
+++ b/crytic_compile/platform/buidler.py
@@ -171,6 +171,10 @@ class Buidler(AbstractPlatform):
                     crytic_compile.filenames.add(path)
                     compilation_unit.asts[path.absolute] = info["ast"]
 
+    def clean(self, **kwargs: str) -> None:
+        # TODO: call "buldler clean"?
+        pass
+
     @staticmethod
     def is_supported(target: str, **kwargs: str) -> bool:
         """Check if the target is a buidler project

--- a/crytic_compile/platform/dapp.py
+++ b/crytic_compile/platform/dapp.py
@@ -116,6 +116,30 @@ class Dapp(AbstractPlatform):
             compiler="solc", version=version, optimized=optimized
         )
 
+    def clean(self, **kwargs: str) -> None:
+        """Clean compilation artifacts
+
+        Args:
+            **kwargs: optional arguments.
+        """
+
+        dapp_ignore_compile = kwargs.get("dapp_ignore_compile", False) or kwargs.get(
+            "ignore_compile", False
+        )
+        if dapp_ignore_compile:
+            return
+
+        cmd = ["dapp", "clean"]
+        LOGGER.info(
+            "'%s' running",
+            " ".join(cmd),
+        )
+        subprocess.run(
+            cmd,
+            cwd=self._target,
+            executable=shutil.which(cmd[0]),
+        )
+
     @staticmethod
     def is_supported(target: str, **kwargs: str) -> bool:
         """Check if the target is a dapp project

--- a/crytic_compile/platform/embark.py
+++ b/crytic_compile/platform/embark.py
@@ -168,6 +168,14 @@ class Embark(AbstractPlatform):
                 natspec = Natspec(userdoc, devdoc)
                 compilation_unit.natspec[contract_name] = natspec
 
+    def clean(self, **_kwargs: str) -> None:
+        """Clean compilation artifacts
+
+        Args:
+            **kwargs: unused.
+        """
+        return
+
     @staticmethod
     def is_supported(target: str, **kwargs: str) -> bool:
         """Check if the target is an embark project

--- a/crytic_compile/platform/etherlime.py
+++ b/crytic_compile/platform/etherlime.py
@@ -157,6 +157,10 @@ class Etherlime(AbstractPlatform):
             compiler=compiler, version=version, optimized=_is_optimized(compile_arguments)
         )
 
+    def clean(self, **_kwargs: str) -> None:
+        # TODO: research if there's a way to clean artifacts
+        pass
+
     @staticmethod
     def is_supported(target: str, **kwargs: str) -> bool:
         """Check if the target is an etherlime project

--- a/crytic_compile/platform/etherscan.py
+++ b/crytic_compile/platform/etherscan.py
@@ -357,6 +357,9 @@ class Etherscan(AbstractPlatform):
 
         solc_standard_json.standalone_compile(filenames, compilation_unit, working_dir=working_dir)
 
+    def clean(self, **_kwargs: str) -> None:
+        pass
+
     @staticmethod
     def is_supported(target: str, **kwargs: str) -> bool:
         """Check if the target is a etherscan project

--- a/crytic_compile/platform/foundry.py
+++ b/crytic_compile/platform/foundry.py
@@ -157,6 +157,14 @@ class Foundry(AbstractPlatform):
             compiler=compiler, version=version, optimized=optimized, optimize_runs=runs
         )
 
+    def clean(self, **_kwargs: str) -> None:
+        """Clean compilation artifacts
+
+        Args:
+            **kwargs: unused.
+        """
+        return
+
     @staticmethod
     def is_supported(target: str, **kwargs: str) -> bool:
         """Check if the target is a foundry project

--- a/crytic_compile/platform/solc.py
+++ b/crytic_compile/platform/solc.py
@@ -182,6 +182,14 @@ class Solc(AbstractPlatform):
                 crytic_compile.filenames.add(path)
                 compilation_unit.asts[path.absolute] = info["AST"]
 
+    def clean(self, **_kwargs: str) -> None:
+        """Clean compilation artifacts
+
+        Args:
+            **kwargs: unused.
+        """
+        return
+
     @staticmethod
     def is_supported(target: str, **kwargs: str) -> bool:
         """Check if the target is a Solidity file

--- a/crytic_compile/platform/standard.py
+++ b/crytic_compile/platform/standard.py
@@ -93,6 +93,14 @@ class Standard(AbstractPlatform):
         self._underlying_platform = platform
         self._unit_tests = unit_tests
 
+    def clean(self, **_kwargs: str) -> None:
+        """Clean compilation artifacts
+
+        Args:
+            **kwargs: unused.
+        """
+        return
+
     @staticmethod
     def is_supported(target: str, **kwargs: str) -> bool:
         """Check if the target has the standard crytic-compile format

--- a/crytic_compile/platform/truffle.py
+++ b/crytic_compile/platform/truffle.py
@@ -278,6 +278,14 @@ class Truffle(AbstractPlatform):
             compiler=compiler, version=version, optimized=optimized
         )
 
+    def clean(self, **_kwargs: str) -> None:
+        """Clean compilation artifacts
+
+        Args:
+            **kwargs: unused.
+        """
+        return
+
     @staticmethod
     def is_supported(target: str, **kwargs: str) -> bool:
         """Check if the target is a truffle project

--- a/crytic_compile/platform/vyper.py
+++ b/crytic_compile/platform/vyper.py
@@ -87,6 +87,14 @@ class Vyper(AbstractPlatform):
         ast = _get_vyper_ast(target, vyper)
         compilation_unit.asts[contract_filename.absolute] = ast
 
+    def clean(self, **_kwargs: str) -> None:
+        """Clean compilation artifacts
+
+        Args:
+            **kwargs: unused.
+        """
+        return
+
     def is_dependency(self, _path: str) -> bool:
         """Check if the path is a dependency (not supported for vyper)
 

--- a/crytic_compile/platform/waffle.py
+++ b/crytic_compile/platform/waffle.py
@@ -219,6 +219,14 @@ class Waffle(AbstractPlatform):
             compiler=compiler, version=version, optimized=optimized
         )
 
+    def clean(self, **_kwargs: str) -> None:
+        """Clean compilation artifacts
+
+        Args:
+            **kwargs: unused.
+        """
+        return
+
     @staticmethod
     def is_supported(target: str, **kwargs: str) -> bool:
         """Check if the target is a waffle project


### PR DESCRIPTION
A common issue experienced by Slither users are crashes due to out of date artifacts, which often can be resolved by running a project clean. This adds a clean function to the multiple platforms to do be able to do this, and defaults to running it unless ignore_compile or skip_clean are enabled.