### PR TITLE
CI: update Actions versions and enable dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+    - package-ecosystem: "github-actions"
+      directory: "/"
+      schedule:
+        interval: "weekly"

--- a/.github/workflows/black.yml
+++ b/.github/workflows/black.yml
@@ -17,10 +17,10 @@ jobs:
 
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Set up Python 3.8
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: 3.8
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,7 +49,7 @@ jobs:
       with:
         node-version: ${{ steps.node.outputs.version }}
     - name: Set up Python 3.8
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@v4
       with:
         python-version: 3.8
     - name: Install dependencies
@@ -59,10 +59,10 @@ jobs:
         pip install .
     - name: Set up nix
       if: matrix.type == 'dapp'
-      uses: cachix/install-nix-action@v16
+      uses: cachix/install-nix-action@v18
     - name: Set up cachix
       if: matrix.type == 'dapp'
-      uses: cachix/cachix-action@v10
+      uses: cachix/cachix-action@v12
       with:
         name: dapp
     - name: Run Tests

--- a/.github/workflows/darglint.yml
+++ b/.github/workflows/darglint.yml
@@ -13,9 +13,9 @@ jobs:
   tests:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v3
     - name: Set up Python 3.8
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v4
       with:
         python-version: 3.8
     - name: Run Tests

--- a/.github/workflows/etherscan.yml
+++ b/.github/workflows/etherscan.yml
@@ -27,7 +27,7 @@ jobs:
         echo 'C:\msys64\mingw64\bin' >> "$GITHUB_PATH"
         echo 'C:\msys64\usr\bin' >> "$GITHUB_PATH"
     - name: Set up Python 3.8
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@v4
       with:
         python-version: 3.8
     - name: Install dependencies

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -17,10 +17,10 @@ jobs:
 
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Set up Python 3.8
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: 3.8
 

--- a/.github/workflows/mypy.yml
+++ b/.github/workflows/mypy.yml
@@ -17,10 +17,10 @@ jobs:
 
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Set up Python 3.8
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: 3.8
 

--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -17,10 +17,10 @@ jobs:
 
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Set up Python 3.8
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: 3.8
 


### PR DESCRIPTION
I spotted some deprecation warnings in the workflows that are fixed in newer versions of actions, so this PR updates all the ones I found out of date and enables dependabot to keep them fresh going forward.