### PR TITLE
etherscan: don't compress paths containing "contracts"

### DIFF
--- a/crytic_compile/platform/etherscan.py
+++ b/crytic_compile/platform/etherscan.py
@@ -150,10 +150,6 @@ def _handle_multiple_files(
     filtered_paths: List[str] = []
     for filename, source_code in source_codes.items():
         path_filename = PurePosixPath(filename)
-        if "contracts" in path_filename.parts and not filename.startswith("@"):
-            path_filename = PurePosixPath(
-                *path_filename.parts[path_filename.parts.index("contracts") :]
-            )
 
         # Convert "absolute" paths such as "/interfaces/IFoo.sol" into relative ones.
         # This is needed due to the following behavior from pathlib.Path:


### PR DESCRIPTION
Partially fixes https://github.com/crytic/crytic-compile/issues/150. After this patch slither successfully runs for 2 of the 3 addresses (`0xcE4a49d7ed99C7c8746B713EE2f0C9aA631688d8` and `0x640022f8a9f00992fa63ee6bae25c2829deadd2d`) mentioned in that issue. The other target still fails, this time with a different error (`File outside of allowed directories` instead of `File not found.`):
```
$ crytic-compile 0x2a311e451491091d2a1d3c43f4f5744bdb4e773a
...
ParserError: home/cluracan/code/0x-protocol/contracts/zero-ex/node_modules/@0x/contracts-erc20/contracts/src/v06/LibERC20TokenV06.sol:23:1: ParserError: Source "@0x/contracts-utils/contracts/src/v06/LibBytesV06.sol" not found: File outside of allowed directories.
import "@0x/contracts-utils/contracts/src/v06/LibBytesV06.sol";
^-------------------------------------------------------------^
```