### PR TITLE
Refactor filenames/filenames_lookup

### DIFF
--- a/crytic_compile/crytic_compile.py
+++ b/crytic_compile/crytic_compile.py
@@ -19,7 +19,6 @@ from crytic_compile.platform.abstract_platform import AbstractPlatform
 from crytic_compile.platform.all_export import PLATFORMS_EXPORT
 from crytic_compile.platform.solc import Solc
 from crytic_compile.platform.standard import export_to_standard
-from crytic_compile.platform.truffle import Truffle
 from crytic_compile.utils.naming import Filename
 from crytic_compile.utils.npm import get_package_name
 from crytic_compile.utils.zip import load_from_zip
@@ -77,12 +76,6 @@ class CryticCompile:
 
         # dependencies is needed for platform conversion
         self._dependencies: Set = set()
-
-        # set containing all the filenames
-        self._filenames: Set[Filename] = set()
-
-        # mapping from absolute/relative/used to filename
-        self._filenames_lookup: Optional[Dict[str, Filename]] = None
 
         self._src_content: Dict = {}
 
@@ -152,27 +145,21 @@ class CryticCompile:
 
     ###################################################################################
     ###################################################################################
-    # region Filenames
+    # region Utils
     ###################################################################################
     ###################################################################################
-
     @property
     def filenames(self) -> Set[Filename]:
-        """All the project filenames
+        """
+        Return the set of all the filenames used
 
         Returns:
-            Set[Filename]: Project's filenames
+             Set[Filename]: list of filenames
         """
-        return self._filenames
-
-    @filenames.setter
-    def filenames(self, all_filenames: Set[Filename]) -> None:
-        """Set the filenames
-
-        Args:
-            all_filenames (Set[Filename]): New filenames
-        """
-        self._filenames = all_filenames
+        filenames: Set[Filename] = set()
+        for compile_unit in self._compilation_units.values():
+            filenames = filenames.union(compile_unit.filenames)
+        return filenames
 
     def filename_lookup(self, filename: str) -> Filename:
         """Return a crytic_compile.naming.Filename from a any filename
@@ -186,21 +173,13 @@ class CryticCompile:
         Returns:
             Filename: Associated Filename object
         """
+        for compile_unit in self.compilation_units.values():
+            try:
+                return compile_unit.filename_lookup(filename)
+            except ValueError:
+                pass
 
-        if isinstance(self.platform, Truffle) and filename.startswith("project:/"):
-            filename = filename[len("project:/") :]
-
-        if self._filenames_lookup is None:
-            self._filenames_lookup = {}
-            for file in self._filenames:
-                self._filenames_lookup[file.absolute] = file
-                self._filenames_lookup[file.relative] = file
-                self._filenames_lookup[file.used] = file
-        if filename not in self._filenames_lookup:
-            raise ValueError(
-                f"{filename} does not exist in {[f.absolute for f in self._filenames_lookup.values()]}"
-            )
-        return self._filenames_lookup[filename]
+        raise ValueError(f"{filename} does not exist")
 
     @property
     def dependencies(self) -> Set[str]:

--- a/crytic_compile/platform/standard.py
+++ b/crytic_compile/platform/standard.py
@@ -416,16 +416,15 @@ def _load_from_compile_0_0_1(crytic_compile: "CryticCompile", loaded_json: Dict)
                     crytic_compile.dependencies.add(filename.short)
                     crytic_compile.dependencies.add(filename.used)
 
-            compilation_unit.filenames = {
-                _convert_dict_to_filename(filename)
-                for filename in compilation_unit_json["filenames"]
-            }
+        compilation_unit.filenames = {
+            _convert_dict_to_filename(filename) for filename in compilation_unit_json["filenames"]
+        }
 
-            for path, ast in compilation_unit_json["asts"].items():
-                # The following might create lookup issue?
-                filename = crytic_compile.filename_lookup(path)
-                source_unit = compilation_unit.create_source_unit(filename)
-                source_unit.ast = ast
+        for path, ast in compilation_unit_json["asts"].items():
+            # The following might create lookup issue?
+            filename = crytic_compile.filename_lookup(path)
+            source_unit = compilation_unit.create_source_unit(filename)
+            source_unit.ast = ast
 
 
 def _load_from_compile_current(crytic_compile: "CryticCompile", loaded_json: Dict) -> None:
@@ -466,16 +465,15 @@ def _load_from_compile_current(crytic_compile: "CryticCompile", loaded_json: Dic
                     crytic_compile.dependencies.add(filename.short)
                     crytic_compile.dependencies.add(filename.used)
 
-            for path, ast in compilation_unit_json["asts"].items:
-                # The following might create lookup issue?
-                filename = convert_filename(path, lambda x: x, crytic_compile)
-                source_unit = compilation_unit.create_source_unit(filename)
-                source_unit.ast = ast
+        compilation_unit.filenames = {
+            _convert_dict_to_filename(filename) for filename in compilation_unit_json["filenames"]
+        }
 
-            compilation_unit.filenames = {
-                _convert_dict_to_filename(filename)
-                for filename in compilation_unit_json["filenames"]
-            }
+        for path, ast in compilation_unit_json["asts"].items:
+            # The following might create lookup issue?
+            filename = convert_filename(path, lambda x: x, crytic_compile)
+            source_unit = compilation_unit.create_source_unit(filename)
+            source_unit.ast = ast
 
 
 def load_from_compile(crytic_compile: "CryticCompile", loaded_json: Dict) -> Tuple[int, List[str]]:
@@ -490,7 +488,6 @@ def load_from_compile(crytic_compile: "CryticCompile", loaded_json: Dict) -> Tup
         Tuple[int, List[str]]: (underlying platform types, guessed unit tests)
     """
     crytic_compile.package_name = loaded_json.get("package", None)
-
     if "compilation_units" not in loaded_json:
         _load_from_compile_legacy1(crytic_compile, loaded_json)
 
@@ -501,10 +498,6 @@ def load_from_compile(crytic_compile: "CryticCompile", loaded_json: Dict) -> Tup
         _load_from_compile_0_0_1(crytic_compile, loaded_json)
     else:
         _load_from_compile_current(crytic_compile, loaded_json)
-
-    # Set our filenames
-    for compilation_unit in crytic_compile.compilation_units.values():
-        crytic_compile.filenames |= set(compilation_unit.filenames)
 
     crytic_compile.working_dir = loaded_json["working_dir"]
 

--- a/crytic_compile/platform/waffle.py
+++ b/crytic_compile/platform/waffle.py
@@ -192,7 +192,6 @@ class Waffle(AbstractPlatform):
             source_unit = compilation_unit.create_source_unit(filename)
 
             source_unit.ast = target_all["sources"][contract[0]]["AST"]
-            crytic_compile.filenames.add(filename)
             compilation_unit.filenames.add(filename)
             compilation_unit.filename_to_contracts[filename].add(contract_name)
             source_unit.contracts_names.add(contract_name)


### PR DESCRIPTION
- Store the information always in the compilation unit CryticCompile 
- use then the underlying compilation unit

This removes duplicate logic and clean the lookups