### PR TITLE
335 dup: Fix for redundant compiles and incorrect version selection when running with solc_solcs_select flag

### DIFF
--- a/crytic_compile/platform/solc.py
+++ b/crytic_compile/platform/solc.py
@@ -584,6 +584,7 @@ def _run_solcs_path(
     targets_json = None
     if isinstance(solcs_path, dict):
         guessed_solcs = _guess_solc(filename, working_dir)
+        compilation_errors = []
         for guessed_solc in guessed_solcs:
             if not guessed_solc in solcs_path:
                 continue
@@ -624,12 +625,14 @@ def _run_solcs_path(
                     working_dir=working_dir,
                     force_legacy_json=force_legacy_json,
                 )
-            except InvalidCompilation:
+                break
+            except InvalidCompilation as ic:
+                compilation_errors.append(version_env+': '+ic.args[0])
                 pass
 
     if not targets_json:
         raise InvalidCompilation(
-            "Invalid solc compilation, none of the solc versions provided worked"
+            "Invalid solc compilation, none of the solc versions provided worked:\n"+'\n'.join(compilation_errors)
         )
 
     return targets_json
@@ -672,6 +675,7 @@ def _run_solcs_env(
     env = dict(os.environ) if env is None else env
     targets_json = None
     guessed_solcs = _guess_solc(filename, working_dir)
+    compilation_errors = []
     for guessed_solc in guessed_solcs:
         if solcs_env and not guessed_solc in solcs_env:
             continue
@@ -688,6 +692,7 @@ def _run_solcs_env(
                 working_dir=working_dir,
                 force_legacy_json=force_legacy_json,
             )
+            break
         except InvalidCompilation:
             pass
 
@@ -708,12 +713,14 @@ def _run_solcs_env(
                     working_dir=working_dir,
                     force_legacy_json=force_legacy_json,
                 )
-            except InvalidCompilation:
+                break
+            except InvalidCompilation as ic:
+                compilation_errors.append(version_env+': '+ic.args[0])
                 pass
 
     if not targets_json:
         raise InvalidCompilation(
-            "Invalid solc compilation, none of the solc versions provided worked"
+            "Invalid solc compilation, none of the solc versions provided worked:\n"+'\n'.join(compilation_errors)
         )
 
     return targets_json

--- a/crytic_compile/platform/solc.py
+++ b/crytic_compile/platform/solc.py
@@ -627,12 +627,12 @@ def _run_solcs_path(
                 )
                 break
             except InvalidCompilation as ic:
-                compilation_errors.append(version_env+': '+ic.args[0])
+                compilation_errors.append(solc_bin + ': ' + ic.args[0])
                 pass
 
     if not targets_json:
         raise InvalidCompilation(
-            "Invalid solc compilation, none of the solc versions provided worked:\n"+'\n'.join(compilation_errors)
+            "Invalid solc compilation, none of the solc versions provided worked:\n" + '\n'.join(compilation_errors)
         )
 
     return targets_json
@@ -715,12 +715,12 @@ def _run_solcs_env(
                 )
                 break
             except InvalidCompilation as ic:
-                compilation_errors.append(version_env+': '+ic.args[0])
+                compilation_errors.append(version_env + ': ' + ic.args[0])
                 pass
 
     if not targets_json:
         raise InvalidCompilation(
-            "Invalid solc compilation, none of the solc versions provided worked:\n"+'\n'.join(compilation_errors)
+            "Invalid solc compilation, none of the solc versions provided worked:\n" + '\n'.join(compilation_errors)
         )
 
     return targets_json

--- a/crytic_compile/platform/solc.py
+++ b/crytic_compile/platform/solc.py
@@ -627,12 +627,11 @@ def _run_solcs_path(
                 )
                 break
             except InvalidCompilation as ic:
-                compilation_errors.append(solc_bin + ': ' + ic.args[0])
-                pass
+                compilation_errors.append(solc_bin + ": " + ic.args[0])
 
     if not targets_json:
         raise InvalidCompilation(
-            "Invalid solc compilation, none of the solc versions provided worked:\n" + '\n'.join(compilation_errors)
+            "Invalid solc compilation, none of the solc versions provided worked:\n" + "\n".join(compilation_errors)
         )
 
     return targets_json
@@ -715,12 +714,11 @@ def _run_solcs_env(
                 )
                 break
             except InvalidCompilation as ic:
-                compilation_errors.append(version_env + ': ' + ic.args[0])
-                pass
+                compilation_errors.append(version_env + ": " + ic.args[0])
 
     if not targets_json:
         raise InvalidCompilation(
-            "Invalid solc compilation, none of the solc versions provided worked:\n" + '\n'.join(compilation_errors)
+            "Invalid solc compilation, none of the solc versions provided worked:\n" + "\n".join(compilation_errors)
         )
 
     return targets_json

--- a/crytic_compile/platform/solc.py
+++ b/crytic_compile/platform/solc.py
@@ -631,7 +631,8 @@ def _run_solcs_path(
 
     if not targets_json:
         raise InvalidCompilation(
-            "Invalid solc compilation, none of the solc versions provided worked:\n" + "\n".join(compilation_errors)
+            "Invalid solc compilation, none of the solc versions provided worked:\n"
+            + "\n".join(compilation_errors)
         )
 
     return targets_json
@@ -718,7 +719,8 @@ def _run_solcs_env(
 
     if not targets_json:
         raise InvalidCompilation(
-            "Invalid solc compilation, none of the solc versions provided worked:\n" + "\n".join(compilation_errors)
+            "Invalid solc compilation, none of the solc versions provided worked:\n"
+            + "\n".join(compilation_errors)
         )
 
     return targets_json


### PR DESCRIPTION
Added break statements to loops in _run_solcs_env and _run_solcs_path to return on first successful compilation instead of last. Also added consolidated compilation error outputs to allow for easier debugging.

When using a large range that includes earlier versions, this would sometimes select version 3.6, which causes other issues due to different output formats.

Fixes #314
closes #335