### PR TITLE
232 dup: feat: add new platforms to "--supported-platforms"

### DIFF
--- a/crytic_compile/platform/all_platforms.py
+++ b/crytic_compile/platform/all_platforms.py
@@ -8,7 +8,22 @@ from .buidler import Buidler
 from .dapp import Dapp
 from .embark import Embark
 from .etherlime import Etherlime
-from .etherscan import Etherscan
+from .etherscan import (
+    Etherscan,
+    Kovan,
+    Ropsten,
+    Rinkeby,
+    Goerli,
+    Arbitrum,
+    ArbitrumTestnet,
+    Avalanche,
+    AvalancheTestnet,
+    Binance,
+    BinanceTestnet,
+    Fantom,
+    Tobalaba,
+    Polygon,
+)
 from .hardhat import Hardhat
 from .solc import Solc
 from .solc_standard_json import SolcStandardJson

--- a/crytic_compile/platform/etherscan.py
+++ b/crytic_compile/platform/etherscan.py
@@ -33,7 +33,7 @@ ETHERSCAN_BASE_BYTECODE = "https://%s/address/%s#code"
 
 SUPPORTED_NETWORK = {
     # Key, (prefix_base, perfix_bytecode)
-    "mainet:": (".etherscan.io", "etherscan.io"),
+    "mainnet:": (".etherscan.io", "etherscan.io"),
     "optim:": ("-optimistic.etherscan.io", "optimistic.etherscan.io"),
     "ropsten:": ("-ropsten.etherscan.io", "ropsten.etherscan.io"),
     "kovan:": ("-kovan.etherscan.io", "kovan.etherscan.io"),
@@ -419,3 +419,107 @@ def _relative_to_short(relative: Path) -> Path:
         Path: Translated path
     """
     return relative
+
+
+class Ropsten(Etherscan):
+    """Ropsten Etherscan"""
+
+    NAME = "Ropsten"
+    PROJECT_URL = "https://ropsten.etherscan.io"
+    TYPE = Type.ETHERSCAN
+
+
+class Kovan(Etherscan):
+    """Kovan Etherscan"""
+
+    NAME = "Kovan"
+    PROJECT_URL = "https://kovan.etherscan.io"
+    TYPE = Type.ETHERSCAN
+
+
+class Rinkeby(Etherscan):
+    """Rinkeby Etherscan"""
+
+    NAME = "Rinkeby"
+    PROJECT_URL = "https://rinkeby.etherscan.io"
+    TYPE = Type.ETHERSCAN
+
+
+class Goerli(Etherscan):
+    """Goerli Etherscan"""
+
+    NAME = "Goerli"
+    PROJECT_URL = "https://goerli.etherscan.io"
+    TYPE = Type.ETHERSCAN
+
+
+class Tobalaba(Etherscan):
+    """Tobalaba Etherscan"""
+
+    NAME = "Tobalaba"
+    PROJECT_URL = "https://tobalaba.etherscan.io"
+    TYPE = Type.ETHERSCAN
+
+
+class Binance(Etherscan):
+    """Binance Etherscan"""
+
+    NAME = "Binance Smart Chain"
+    PROJECT_URL = "https://bscscan.com"
+    TYPE = Type.ETHERSCAN
+
+
+class BinanceTestnet(Etherscan):
+    """Binance Testnet Etherscan"""
+
+    NAME = "Binance Smart Chain Testnet"
+    PROJECT_URL = "https://testnet.bscscan.com"
+    TYPE = Type.ETHERSCAN
+
+
+class Arbitrum(Etherscan):
+    """Artbitrum Etherscan"""
+
+    NAME = "Arbitrum"
+    PROJECT_URL = "https://arbiscan.io"
+    TYPE = Type.ETHERSCAN
+
+
+class ArbitrumTestnet(Etherscan):
+    """Artbitrum Testnet Etherscan"""
+
+    NAME = "Arbitrum Testnet"
+    PROJECT_URL = "https://testnet.arbiscan.io"
+    TYPE = Type.ETHERSCAN
+
+
+class Polygon(Etherscan):
+    """Polygon Etherscan"""
+
+    NAME = "Polygon"
+    PROJECT_URL = "https://polygonscan.com"
+    TYPE = Type.ETHERSCAN
+
+
+class Avalanche(Etherscan):
+    """Avalanche Etherscan"""
+
+    NAME = "Avalanche"
+    PROJECT_URL = "https://snowtrace.io"
+    TYPE = Type.ETHERSCAN
+
+
+class AvalancheTestnet(Etherscan):
+    """Avalanche Testnet Etherscan"""
+
+    NAME = "Avalanche Testnet"
+    PROJECT_URL = "https://testnet.snowtrace.io"
+    TYPE = Type.ETHERSCAN
+
+
+class Fantom(Etherscan):
+    """Fantom Etherscan"""
+
+    NAME = "Fantom"
+    PROJECT_URL = "https://ftmscan.com"
+    TYPE = Type.ETHERSCAN


### PR DESCRIPTION
Closes https://github.com/crytic/crytic-compile/issues/231 I updated the wiki. also added it to the CLI since I regularly check what chains crytic-compile supports when using slither and find that useful. This PR adds non-mainnet chains with etherscan-like explorers to supported platforms. (I also fixed the spelling of `mainet` to `mainnet`)

Current output of `crytic-compile --supported-platforms`
```
INFO:CryticCompile:
- solc: https://github.com/ethereum/solidity
- Truffle: https://github.com/trufflesuite/truffle
- Embark: https://github.com/embarklabs/embark
- Dapp: https://github.com/dapphub/dapptools
- Etherlime: https://github.com/LimeChain/etherlime
- Etherscan: https://etherscan.io/
- vyper: https://github.com/vyperlang/vyper
- Waffle: https://github.com/EthWorks/Waffle
- Brownie: https://github.com/iamdefinitelyahuman/brownie
- Solc-json: https://solidity.readthedocs.io/en/latest/using-the-compiler.html#compiler-input-and-output-json-description
- Buidler: https://github.com/nomiclabs/buidler
- Hardhat: https://github.com/nomiclabs/hardhat
- Standard: https://github.com/crytic/crytic-compile
- Archive: https://github.com/crytic/crytic-compile
```

After this PR
```
INFO:CryticCompile:
- solc: https://github.com/ethereum/solidity
- Truffle: https://github.com/trufflesuite/truffle
- Embark: https://github.com/embarklabs/embark
- Dapp: https://github.com/dapphub/dapptools
- Etherlime: https://github.com/LimeChain/etherlime
- Arbitrum: https://arbiscan.io
- Arbitrum Testnet: https://testnet.arbiscan.io
- Avalanche: https://snowtrace.io
- Avalanche Testnet: https://testnet.snowtrace.io
- Binance Smart Chain: https://bscscan.com
- Binance Smart Chain Testnet: https://testnet.bscscan.com
- Etherscan: https://etherscan.io/
- Fantom: https://ftmscan.com
- Goerli: https://goerli.etherscan.io
- Kovan: https://kovan.etherscan.io
- Polygon: https://polygonscan.com
- Rinkeby: https://rinkeby.etherscan.io
- Ropsten: https://ropsten.etherscan.io
- Tobalaba: https://tobalaba.etherscan.io
- vyper: https://github.com/vyperlang/vyper
- Waffle: https://github.com/EthWorks/Waffle
- Brownie: https://github.com/iamdefinitelyahuman/brownie
- Solc-json: https://solidity.readthedocs.io/en/latest/using-the-compiler.html#compiler-input-and-output-json-description
- Buidler: https://github.com/nomiclabs/buidler
- Hardhat: https://github.com/nomiclabs/hardhat
- Standard: https://github.com/crytic/crytic-compile
- Archive: https://github.com/crytic/crytic-compile

```

closes #232 