### PR TITLE
Decode debugging and error output with backslashreplace

### DIFF
--- a/crytic_compile/crytic_compile.py
+++ b/crytic_compile/crytic_compile.py
@@ -547,8 +547,8 @@ class CryticCompile:
         with subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE) as process:
             stdout_bytes, stderr_bytes = process.communicate()
             stdout, stderr = (
-                stdout_bytes.decode(),
-                stderr_bytes.decode(),
+                stdout_bytes.decode(errors="backslashreplace"),
+                stderr_bytes.decode(errors="backslashreplace"),
             )  # convert bytestrings to unicode strings
 
             LOGGER.info(stdout)

--- a/crytic_compile/platform/brownie.py
+++ b/crytic_compile/platform/brownie.py
@@ -63,8 +63,8 @@ class Brownie(AbstractPlatform):
                 ) as process:
                     stdout_bytes, stderr_bytes = process.communicate()
                     stdout, stderr = (
-                        stdout_bytes.decode(),
-                        stderr_bytes.decode(),
+                        stdout_bytes.decode(errors="backslashreplace"),
+                        stderr_bytes.decode(errors="backslashreplace"),
                     )  # convert bytestrings to unicode strings
 
                     LOGGER.info(stdout)

--- a/crytic_compile/platform/buidler.py
+++ b/crytic_compile/platform/buidler.py
@@ -80,8 +80,8 @@ class Buidler(AbstractPlatform):
 
                 stdout_bytes, stderr_bytes = process.communicate()
                 stdout, stderr = (
-                    stdout_bytes.decode(),
-                    stderr_bytes.decode(),
+                    stdout_bytes.decode(errors="backslashreplace"),
+                    stderr_bytes.decode(errors="backslashreplace"),
                 )  # convert bytestrings to unicode strings
 
                 LOGGER.info(stdout)

--- a/crytic_compile/platform/embark.py
+++ b/crytic_compile/platform/embark.py
@@ -104,10 +104,10 @@ class Embark(AbstractPlatform):
                 # pylint: disable=raise-missing-from
                 raise InvalidCompilation(error)
             stdout, stderr = process.communicate()
-            LOGGER.info("%s\n", stdout.decode())
+            LOGGER.info("%s\n", stdout.decode(errors="backslashreplace"))
             if stderr:
                 # Embark might return information to stderr, but compile without issue
-                LOGGER.error("%s", stderr.decode())
+                LOGGER.error("%s", stderr.decode(errors="backslashreplace"))
         infile = os.path.join(self._target, "crytic-export", "contracts-embark.json")
         if not os.path.isfile(infile):
             raise InvalidCompilation(

--- a/crytic_compile/platform/etherlime.py
+++ b/crytic_compile/platform/etherlime.py
@@ -57,8 +57,8 @@ def _run_etherlime(target: str, npx_disable: bool, compile_arguments: Optional[s
         ) as process:
             stdout_bytes, stderr_bytes = process.communicate()
             stdout, stderr = (
-                stdout_bytes.decode(),
-                stderr_bytes.decode(),
+                stdout_bytes.decode(errors="backslashreplace"),
+                stderr_bytes.decode(errors="backslashreplace"),
             )  # convert bytestrings to unicode strings
 
             LOGGER.info(stdout)

--- a/crytic_compile/platform/foundry.py
+++ b/crytic_compile/platform/foundry.py
@@ -87,8 +87,8 @@ class Foundry(AbstractPlatform):
 
                 stdout_bytes, stderr_bytes = process.communicate()
                 stdout, stderr = (
-                    stdout_bytes.decode(),
-                    stderr_bytes.decode(),
+                    stdout_bytes.decode(errors="backslashreplace"),
+                    stderr_bytes.decode(errors="backslashreplace"),
                 )  # convert bytestrings to unicode strings
 
                 LOGGER.info(stdout)

--- a/crytic_compile/platform/hardhat.py
+++ b/crytic_compile/platform/hardhat.py
@@ -79,8 +79,8 @@ class Hardhat(AbstractPlatform):
 
                 stdout_bytes, stderr_bytes = process.communicate()
                 stdout, stderr = (
-                    stdout_bytes.decode(),
-                    stderr_bytes.decode(),
+                    stdout_bytes.decode(errors="backslashreplace"),
+                    stderr_bytes.decode(errors="backslashreplace"),
                 )  # convert bytestrings to unicode strings
 
                 LOGGER.info(stdout)
@@ -308,7 +308,7 @@ class Hardhat(AbstractPlatform):
             stdout_bytes, stderr_bytes = process.communicate(command.encode("utf-8"))
             stdout, stderr = (
                 stdout_bytes.decode(),
-                stderr_bytes.decode(),
+                stderr_bytes.decode(errors="backslashreplace"),
             )
 
             if stderr:

--- a/crytic_compile/platform/solc_standard_json.py
+++ b/crytic_compile/platform/solc_standard_json.py
@@ -157,7 +157,7 @@ def run_solc_standard_json(
             stdout_b, stderr_b = process.communicate(json.dumps(solc_input).encode("utf-8"))
             stdout, stderr = (
                 stdout_b.decode(),
-                stderr_b.decode(),
+                stderr_b.decode(errors="backslashreplace"),
             )  # convert bytestrings to unicode strings
 
             solc_json_output = json.loads(stdout)

--- a/crytic_compile/platform/truffle.py
+++ b/crytic_compile/platform/truffle.py
@@ -176,8 +176,8 @@ class Truffle(AbstractPlatform):
 
                 stdout_bytes, stderr_bytes = process.communicate()
                 stdout, stderr = (
-                    stdout_bytes.decode(),
-                    stderr_bytes.decode(),
+                    stdout_bytes.decode(errors="backslashreplace"),
+                    stderr_bytes.decode(errors="backslashreplace"),
                 )  # convert bytestrings to unicode strings
 
                 if truffle_overwrite_config:

--- a/crytic_compile/platform/waffle.py
+++ b/crytic_compile/platform/waffle.py
@@ -160,9 +160,9 @@ class Waffle(AbstractPlatform):
                     ) as process:
                         stdout, stderr = process.communicate()
                         if stdout:
-                            LOGGER.info(stdout.decode())
+                            LOGGER.info(stdout.decode(errors="backslashreplace"))
                         if stderr:
-                            LOGGER.error(stderr.decode())
+                            LOGGER.error(stderr.decode(errors="backslashreplace"))
                 except OSError as error:
                     # pylint: disable=raise-missing-from
                     raise InvalidCompilation(error)

--- a/crytic_compile/utils/subprocess.py
+++ b/crytic_compile/utils/subprocess.py
@@ -58,7 +58,10 @@ def run(
         LOGGER.error("Could not execute `%s`, is it installed and in PATH?", cmd[0])
     except subprocess.CalledProcessError as e:
         LOGGER.error("'%s' returned non-zero exit code %d", cmd[0], e.returncode)
-        stdout, stderr = (e.stdout.decode().strip(), e.stderr.decode().strip())
+        stdout, stderr = (
+            e.stdout.decode(errors="backslashreplace").strip(),
+            e.stderr.decode(errors="backslashreplace").strip(),
+        )
         if stdout:
             LOGGER.error("\nstdout: ".join(stdout.split("\n")))
         if stderr:


### PR DESCRIPTION
Sometimes tools produce output that is not in UTF-8. Failing because the external tool's info or error messages could not be processed does not provide a good UX. This sprinkles backslashreplace on bytes.decode() for things that are meant to be logged or printed as part of an error or warning message.

Fixes: crytic/slither#1540