### PR TITLE
surface stderr/ errors from solc-select

### DIFF
--- a/crytic_compile/platform/solc.py
+++ b/crytic_compile/platform/solc.py
@@ -384,11 +384,17 @@ def get_version(solc: str, env: Optional[Dict[str, str]]) -> str:
             env=env,
             executable=shutil.which(cmd[0]),
         ) as process:
-            stdout_bytes, _ = process.communicate()
-            stdout = stdout_bytes.decode()  # convert bytestrings to unicode strings
+            stdout_bytes, stderr_bytes = process.communicate()
+            stdout, stderr = (
+                stdout_bytes.decode(errors="backslashreplace"),
+                stderr_bytes.decode(errors="backslashreplace"),
+            )  # convert bytestrings to unicode strings
             version = re.findall(r"\d+\.\d+\.\d+", stdout)
+            print(stdout)
             if len(version) == 0:
-                raise InvalidCompilation(f"Solidity version not found: {stdout}")
+                raise InvalidCompilation(
+                    f"\nSolidity version not found:\nSTDOUT:\n{stdout}\nSTDERR:\n{stderr}"
+                )
             return version[0]
     except OSError as error:
         # pylint: disable=raise-missing-from

--- a/crytic_compile/platform/solc.py
+++ b/crytic_compile/platform/solc.py
@@ -390,7 +390,6 @@ def get_version(solc: str, env: Optional[Dict[str, str]]) -> str:
                 stderr_bytes.decode(errors="backslashreplace"),
             )  # convert bytestrings to unicode strings
             version = re.findall(r"\d+\.\d+\.\d+", stdout)
-            print(stdout)
             if len(version) == 0:
                 raise InvalidCompilation(
                     f"\nSolidity version not found:\nSTDOUT:\n{stdout}\nSTDERR:\n{stderr}"


### PR DESCRIPTION
Close https://github.com/crytic/crytic-compile/issues/352
```
ERROR:CryticCompile:
Solidity version not found:
STDOUT:

STDERR:
Traceback (most recent call last):
  File "/opt/homebrew/bin/solc", line 8, in <module>
    sys.exit(solc())
             ^^^^^^
  File "/opt/homebrew/Cellar/solc-select/1.0.2/libexec/lib/python3.11/site-packages/solc_select/__main__.py", line 80, in solc
    res = current_version()
          ^^^^^^^^^^^^^^^^^
  File "/opt/homebrew/Cellar/solc-select/1.0.2/libexec/lib/python3.11/site-packages/solc_select/solc_select.py", line 60, in current_version
    raise argparse.ArgumentTypeError(
argparse.ArgumentTypeError: No solc version set. Run `solc-select use VERSION` or set SOLC_VERSION environment variable.
```