### PR TITLE
hardhat: consider hardhat console might not execute successfully

### DIFF
--- a/crytic_compile/platform/hardhat.py
+++ b/crytic_compile/platform/hardhat.py
@@ -301,14 +301,17 @@ class Hardhat(AbstractPlatform):
             override_paths["root"] = Path(target_path, args["hardhat_working_dir"])
 
         print_paths = "console.log(JSON.stringify(config.paths))"
-        config_str = self._run_hardhat_console(base_cmd, print_paths)
 
         try:
+            config_str = self._run_hardhat_console(base_cmd, print_paths)
             paths = json.loads(config_str or "{}")
             return {**default_paths, **paths, **override_paths}
         except ValueError as e:
-            LOGGER.info("Problem deserializing hardhat configuration: %s", e)
-            return {**default_paths, **override_paths}
+            LOGGER.info("Problem deserializing hardhat configuration, using defaults: %s", e)
+        except (OSError, subprocess.SubprocessError) as e:
+            LOGGER.info("Problem executing hardhat to fetch configuration, using defaults: %s", e)
+
+        return {**default_paths, **override_paths}
 
     def _run_hardhat_console(self, base_cmd: List[str], command: str) -> Optional[str]:
         """Run a JS command in the hardhat console

--- a/crytic_compile/platform/hardhat.py
+++ b/crytic_compile/platform/hardhat.py
@@ -280,7 +280,7 @@ class Hardhat(AbstractPlatform):
         Returns:
             Dict[str, str]: hardhat paths configuration
         """
-        target_path = Path(self._target)
+        target_path = Path(self._target).resolve()
         default_paths = {
             "root": target_path,
             "configFile": target_path.joinpath("hardhat.config.js"),


### PR DESCRIPTION
Hardhat might not be available in the environment (e.g. if the user passed `--ignore-compile` and does not have it installed), so consider this case and just use the default config with any potential user overrides.

Fixes: crytic/slither-action#48