### PR TITLE
dapp: fix compilations with `target` different from `cwd`

### DIFF
--- a/crytic_compile/platform/dapp.py
+++ b/crytic_compile/platform/dapp.py
@@ -71,7 +71,9 @@ class Dapp(AbstractPlatform):
 
             for original_filename, contracts_info in targets_json["contracts"].items():
 
-                filename = convert_filename(original_filename, lambda x: x, crytic_compile)
+                filename = convert_filename(
+                    original_filename, lambda x: x, crytic_compile, self._target
+                )
 
                 source_unit = compilation_unit.create_source_unit(filename)
 

--- a/scripts/ci_test_dapp.sh
+++ b/scripts/ci_test_dapp.sh
@@ -21,10 +21,34 @@ nix-env -f "$HOME/.dapp/dapptools" -iA dapp seth solc hevm ethsign
 
 dapp init
 
+PROJECT="$PWD"
+
+echo "::group::Dapp + cwd target"
 crytic-compile . --compile-remove-metadata
 if [ $? -ne 0 ]
 then
     echo "dapp test failed"
     exit 255
 fi
+echo "::endgroup::"
 
+cd /tmp || exit 255
+
+echo "::group::Dapp + different target"
+crytic-compile "$PROJECT" --compile-remove-metadata
+if [ $? -ne 0 ]
+then
+    echo "dapp test with different target failed"
+    exit 255
+fi
+echo "::endgroup::"
+
+
+echo "::group::Dapp + different target + ignore compile"
+crytic-compile "$PROJECT" --compile-remove-metadata --ignore-compile
+if [ $? -ne 0 ]
+then
+    echo "dapp test with different target + ignore compile failed"
+    exit 255
+fi
+echo "::endgroup::"


### PR DESCRIPTION
Running `crytic-compile some-folder/` is currently broken for dapp projects (for folders other than `.`), this PR fixes it by passing the correct working directory when resolving file names.