### PR TITLE
Enable custom build output directories with Brownie

### DIFF
--- a/crytic_compile/platform/brownie.py
+++ b/crytic_compile/platform/brownie.py
@@ -45,7 +45,8 @@ class Brownie(AbstractPlatform):
         Raises:
             InvalidCompilation: If brownie failed to run
         """
-        build_directory = _get_build_dir_from_config(self._target) or Path("build", "contracts")
+        base_build_directory = _get_build_dir_from_config(self._target) or "build"
+        build_directory = Path(base_build_directory, "contracts")
         brownie_ignore_compile = kwargs.get("brownie_ignore_compile", False) or kwargs.get(
             "ignore_compile", False
         )
@@ -208,8 +209,7 @@ def _get_build_dir_from_config(target: str) -> Optional[str]:
         return None
 
     with open(config, "r", encoding="utf8") as config_f:
-        config_buffer = config_f.read().split('\n')
-
+        config_buffer = config_f.readlines()
     # config is a yaml file
     # use regex because we don't have a yaml parser
     for line in config_buffer:

--- a/crytic_compile/platform/brownie.py
+++ b/crytic_compile/platform/brownie.py
@@ -201,6 +201,7 @@ def _iterate_over_files(
         compiler=compiler, version=version, optimized=optimized
     )
 
+
 def _get_build_dir_from_config(target: str) -> Optional[str]:
     config = Path(target, "brownie-config.yml")
     if not config.exists():
@@ -213,7 +214,7 @@ def _get_build_dir_from_config(target: str) -> Optional[str]:
     # config is a yaml file
     # use regex because we don't have a yaml parser
     for line in config_buffer:
-        match = re.search(r'build: (.*)$', line)
+        match = re.search(r"build: (.*)$", line)
         if match:
             return match.groups()[0]
     return None


### PR DESCRIPTION
Add support for custom brownie build directories.

crytic-compile fails when it cannot find the build artifacts, but until now did not check the brownie config for custom build directories first.