### PR TITLE
Improve libraries support

### DIFF
--- a/crytic_compile/__main__.py
+++ b/crytic_compile/__main__.py
@@ -99,6 +99,14 @@ see https://github.com/crytic/crytic-compile/wiki""",
     )
 
     parser.add_argument(
+        "--print-libraries",
+        help="Print all the libraries info",
+        action="store_true",
+        dest="print_libraries",
+        default=False,
+    )
+
+    parser.add_argument(
         "--version",
         help="displays the current version",
         version=require("crytic-compile")[0].version,
@@ -185,6 +193,26 @@ def _print_filenames(compilation: "CryticCompile") -> None:
             print(f"\t\tUsed: {filename.used}")
 
 
+def _print_libraries(compilation: "CryticCompile") -> None:
+    for compilation_id, compilation_unit in compilation.compilation_units.items():
+        print(
+            f"Compilation unit: {compilation_id} solc {compilation_unit.compiler_version.version})"
+        )
+
+        libraries_to_update = compilation.libraries
+
+        print(libraries_to_update)
+        for source_unit in compilation_unit.source_units.values():
+            for contract in source_unit.contracts_names_without_libraries:
+                libs = source_unit.libraries_names(contract)
+                if libs:
+                    print(f"## {contract}")
+                    print(f"\tuses: {libs}")
+                    print(
+                        f"\truntime bytecode: {source_unit.bytecode_runtime(contract, libraries_to_update)}"
+                    )
+
+
 def main() -> None:
     """Main function run from the cli"""
     args = parse_args()
@@ -198,6 +226,8 @@ def main() -> None:
             # Print the filename of each contract (no duplicates).
             if args.print_filename:
                 _print_filenames(compilation)
+            if args.print_libraries:
+                _print_libraries(compilation)
             if args.export_format:
                 compilation.export(**vars(args))
 

--- a/crytic_compile/crytic_compile.py
+++ b/crytic_compile/crytic_compile.py
@@ -7,6 +7,7 @@ import inspect
 import json
 import logging
 import os
+import re
 import subprocess
 import tempfile
 from collections import defaultdict
@@ -58,6 +59,24 @@ def is_supported(target: str) -> bool:
     return any(platform.is_supported(target) for platform in platforms) or target.endswith(".zip")
 
 
+def _extract_libraries(libraries_str: Optional[str]) -> Optional[Dict[str, int]]:
+
+    if not libraries_str:
+        return None
+
+    pattern = r"\((?P<name>\w+),\s*(?P<value1>0x[0-9a-fA-F]{2})\),?"
+    matches = re.findall(pattern, libraries_str)
+
+    if not matches:
+        logging.info(f"Libraries {libraries_str} could not be parsed")
+        return None
+
+    ret: Dict[str, int] = {}
+    for key, value in matches:
+        ret[key] = int(value, 16) if value.startswith("0x") else int(value)
+    return ret
+
+
 # pylint: disable=too-many-instance-attributes
 class CryticCompile:
     """
@@ -106,6 +125,8 @@ class CryticCompile:
         self._compilation_units: Dict[str, CompilationUnit] = {}
 
         self._bytecode_only = False
+
+        self.libraries: Optional[Dict[str, int]] = _extract_libraries(kwargs.get("compile_libraries", None))  # type: ignore
 
         self._compile(**kwargs)
 

--- a/crytic_compile/cryticparser/cryticparser.py
+++ b/crytic_compile/cryticparser/cryticparser.py
@@ -29,6 +29,13 @@ def init(parser: ArgumentParser) -> None:
     )
 
     group_compile.add_argument(
+        "--compile-libraries",
+        help='Libraries used for linking. Format: --compile-libraries "(name1, 0x00),(name2, 0x02)"',
+        action="store",
+        default=DEFAULTS_FLAG_IN_CONFIG["compile_libraries"],
+    )
+
+    group_compile.add_argument(
         "--compile-remove-metadata",
         help="Remove the metadata from the bytecodes",
         action="store_true",

--- a/crytic_compile/cryticparser/defaults.py
+++ b/crytic_compile/cryticparser/defaults.py
@@ -46,4 +46,5 @@ DEFAULTS_FLAG_IN_CONFIG = {
     "foundry_ignore_compile": False,
     "foundry_out_directory": "out",
     "export_dir": "crytic-export",
+    "compile_libraries": None,
 }

--- a/crytic_compile/platform/solc.py
+++ b/crytic_compile/platform/solc.py
@@ -34,6 +34,8 @@ LOGGER = logging.getLogger("CryticCompile")
 def _build_contract_data(compilation_unit: "CompilationUnit") -> Dict:
     contracts = {}
 
+    libraries = compilation_unit.crytic_compile.libraries
+
     for filename, source_unit in compilation_unit.source_units.items():
         for contract_name in source_unit.contracts_names:
             abi = str(source_unit.abi(contract_name))
@@ -46,8 +48,8 @@ def _build_contract_data(compilation_unit: "CompilationUnit") -> Dict:
                 "srcmap": ";".join(source_unit.srcmap_init(contract_name)),
                 "srcmap-runtime": ";".join(source_unit.srcmap_runtime(contract_name)),
                 "abi": abi,
-                "bin": source_unit.bytecode_init(contract_name),
-                "bin-runtime": source_unit.bytecode_runtime(contract_name),
+                "bin": source_unit.bytecode_init(contract_name, libraries),
+                "bin-runtime": source_unit.bytecode_runtime(contract_name, libraries),
                 "userdoc": source_unit.natspec[contract_name].userdoc.export(),
                 "devdoc": source_unit.natspec[contract_name].devdoc.export(),
             }

--- a/crytic_compile/platform/standard.py
+++ b/crytic_compile/platform/standard.py
@@ -221,8 +221,10 @@ def generate_standard_export(crytic_compile: "CryticCompile") -> Dict:
     """
 
     compilation_units = {}
+    libraries_to_update = crytic_compile.libraries
     for key, compilation_unit in crytic_compile.compilation_units.items():
         source_unit_dict: Dict[str, Dict[str, Dict[str, Any]]] = {}
+
         for filename, source_unit in compilation_unit.source_units.items():
             source_unit_dict[filename.relative] = defaultdict(dict)
             source_unit_dict[filename.relative]["ast"] = source_unit.ast
@@ -230,8 +232,8 @@ def generate_standard_export(crytic_compile: "CryticCompile") -> Dict:
                 libraries = source_unit.libraries_names_and_patterns(contract_name)
                 source_unit_dict[filename.relative]["contracts"][contract_name] = {
                     "abi": source_unit.abi(contract_name),
-                    "bin": source_unit.bytecode_init(contract_name),
-                    "bin-runtime": source_unit.bytecode_runtime(contract_name),
+                    "bin": source_unit.bytecode_init(contract_name, libraries_to_update),
+                    "bin-runtime": source_unit.bytecode_runtime(contract_name, libraries_to_update),
                     "srcmap": ";".join(source_unit.srcmap_init(contract_name)),
                     "srcmap-runtime": ";".join(source_unit.srcmap_runtime(contract_name)),
                     "filenames": _convert_filename_to_dict(filename),

--- a/crytic_compile/platform/truffle.py
+++ b/crytic_compile/platform/truffle.py
@@ -53,6 +53,9 @@ def export_to_truffle(crytic_compile: "CryticCompile", **kwargs: str) -> List[st
     compilation_unit = compilation_units[0]
 
     # Loop for each contract filename.
+
+    libraries = compilation_unit.crytic_compile.libraries
+
     results: List[Dict] = []
     for source_unit in compilation_unit.source_units.values():
         for contract_name in source_unit.contracts_names:
@@ -60,8 +63,8 @@ def export_to_truffle(crytic_compile: "CryticCompile", **kwargs: str) -> List[st
             output = {
                 "contractName": contract_name,
                 "abi": source_unit.abi(contract_name),
-                "bytecode": "0x" + source_unit.bytecode_init(contract_name),
-                "deployedBytecode": "0x" + source_unit.bytecode_runtime(contract_name),
+                "bytecode": "0x" + source_unit.bytecode_init(contract_name, libraries),
+                "deployedBytecode": "0x" + source_unit.bytecode_runtime(contract_name, libraries),
                 "ast": source_unit.ast,
                 "userdoc": source_unit.natspec[contract_name].userdoc.export(),
                 "devdoc": source_unit.natspec[contract_name].devdoc.export(),


### PR DESCRIPTION
- Add --compile-libraries flag to link the libs. Ex `--compile-libraries "(Lib1,0x01),(Lib2,0x02),(Lib3,0x03),(Lib4,0x04)"`
- Add --print-libraries flag to show some info about the libs
- Refactor the code to make it eaiser to maintain

This is a first step for a refactoring of the libraries. We should probalby cache the lib info to avoid recomputing the candidates multiple times This is a breaking change, as the lib related API will now take a int instead of a str