### PR TITLE
guess solc if pragma is avail, better error if file is a dir

### DIFF
--- a/crytic_compile/platform/solc.py
+++ b/crytic_compile/platform/solc.py
@@ -506,9 +506,9 @@ def _run_solc(
             solc_select.switch_global_version(guessed_version, always_install=True)
             env_version = guessed_version
 
-        compilation_unit.compiler_version = CompilerVersion(
-            compiler="solc", version=env_version, optimized=is_optimized(solc_arguments)
-        )
+    compilation_unit.compiler_version = CompilerVersion(
+        compiler="solc", version=env_version, optimized=is_optimized(solc_arguments)
+    )
 
     compiler_version = compilation_unit.compiler_version
     assert compiler_version


### PR DESCRIPTION
If one runs crytic-compile on a single Solidity file but has the wrong solc version, it will now try to switch to the correct version by parsing the pragma and using solc-select. Also, this adds a more descriptive error if the target is a directory e.g. `crytic-compile .` where no compilation framework is available and the solc platform is used.