### PR TITLE
platform: hardhat: explicitly terminate console after querying paths

### DIFF
--- a/crytic_compile/platform/hardhat.py
+++ b/crytic_compile/platform/hardhat.py
@@ -300,7 +300,7 @@ class Hardhat(AbstractPlatform):
         if args.get("hardhat_working_dir", None):
             override_paths["root"] = Path(target_path, args["hardhat_working_dir"])
 
-        print_paths = "console.log(JSON.stringify(config.paths))"
+        print_paths = "console.log(JSON.stringify(config.paths));process.exit()"
 
         try:
             config_str = self._run_hardhat_console(base_cmd, print_paths)


### PR DESCRIPTION
On some systems the Hardhat console does not appear to terminate when stdin is closed. Explicitly call `process.exit()` to make sure it behaves as expected.

Fixes: #416