### PR TITLE
Update hardhat.py

### DIFF
--- a/crytic_compile/platform/hardhat.py
+++ b/crytic_compile/platform/hardhat.py
@@ -132,10 +132,7 @@ def hardhat_like_parsing(
                         )
 
                     source_unit = compilation_unit.create_source_unit(path)
-                    try:
-                        source_unit.ast = info["ast"]
-                    except:
-                        source_unit.ast = info["legacyAST"]
+                    source_unit.ast = info.get("legacyAST", "ast")
 
 
 class Hardhat(AbstractPlatform):

--- a/crytic_compile/platform/hardhat.py
+++ b/crytic_compile/platform/hardhat.py
@@ -132,7 +132,10 @@ def hardhat_like_parsing(
                         )
 
                     source_unit = compilation_unit.create_source_unit(path)
-                    source_unit.ast = info["ast"]
+                    try:
+                        source_unit.ast = info["ast"]
+                    except:
+                        source_unit.ast = info["legacyAST"]
 
 
 class Hardhat(AbstractPlatform):

--- a/crytic_compile/platform/hardhat.py
+++ b/crytic_compile/platform/hardhat.py
@@ -132,7 +132,7 @@ def hardhat_like_parsing(
                         )
 
                     source_unit = compilation_unit.create_source_unit(path)
-                    source_unit.ast = info.get("legacyAST", "ast")
+                    source_unit.ast = info.get("legacyAST", info["ast"])
 
 
 class Hardhat(AbstractPlatform):


### PR DESCRIPTION
Patch to resolve issues with old compile versions.

Tested on: https://github.com/code-423n4/2023-04-ens

Tested w/ slither which uses crytic-compile as a dependency
```bash
slither-doctor .
slither .
```


