### PR TITLE
prevent possible path traversal for etherscan platform

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,7 @@ jobs:
     - name: Set up Node
       uses: actions/setup-node@v3
       with:
-        node-version: 'lts/*'
+        node-version: 18.15
     - name: Set up Python 3.8
       uses: actions/setup-python@v4
       with:

--- a/crytic_compile/platform/etherscan.py
+++ b/crytic_compile/platform/etherscan.py
@@ -169,6 +169,11 @@ def _handle_multiple_files(
         filtered_paths.append(path_filename.as_posix())
         path_filename_disk = Path(directory, path_filename)
 
+        allowed_path = os.path.abspath(directory)
+        if os.path.commonpath((allowed_path, os.path.abspath(path_filename_disk))) != allowed_path:
+            raise IOError(
+                f"Path '{path_filename_disk}' is outside of the allowed directory: {allowed_path}"
+            )
         if not os.path.exists(path_filename_disk.parent):
             os.makedirs(path_filename_disk.parent)
         with open(path_filename_disk, "w", encoding="utf8") as file_desc:

--- a/crytic_compile/platform/etherscan.py
+++ b/crytic_compile/platform/etherscan.py
@@ -136,6 +136,9 @@ def _handle_multiple_files(
 
     Returns:
         Tuple[List[str], str]: filesnames, directory, where target_filename is the main file
+
+    Raises:
+        IOError: if the path is outside of the allowed directory
     """
     if prefix:
         directory = os.path.join(export_dir, f"{addr}{prefix}-{contract_name}")

--- a/crytic_compile/platform/etherscan.py
+++ b/crytic_compile/platform/etherscan.py
@@ -155,6 +155,10 @@ def _handle_multiple_files(
     filtered_paths: List[str] = []
     for filename, source_code in source_codes.items():
         path_filename = PurePosixPath(filename)
+        # Only keep solidity files
+        if path_filename.suffix not in [".sol", ".vy"]:
+            continue
+
         # https://etherscan.io/address/0x19bb64b80cbf61e61965b0e5c2560cc7364c6546#code has an import of erc721a/contracts/ERC721A.sol
         # if the full path is lost then won't compile
         if "contracts" == path_filename.parts[0] and not filename.startswith("@"):


### PR DESCRIPTION
If a user ran crytic-compile on an address with malicious artifacts verified on etherscan, it was possible to write files on the user's machine by using a relative path e.g. `../../../../.env` to traverse above the export directory (`crytic-export/` ). This fix prevents path traversal by ensuring the absolute path of all files written to disk have a common prefix with the export directory.

Thank you Lucas Ma (https://twitter.com/MaLucasBC) for responsibly disclosing this vulnerability.