### PR TITLE
Fix etherscan rate limit check

### DIFF
--- a/crytic_compile/platform/etherscan.py
+++ b/crytic_compile/platform/etherscan.py
@@ -277,8 +277,9 @@ class Etherscan(AbstractPlatform):
 
             if (
                 "result" in info
-                and info["result"]
-                == "Max rate limit reached, please use API Key for higher rate limit"
+                and "rate limit reached" in info["result"]
+                and "message" in info
+                and info["message"] == "NOTOK"
             ):
                 LOGGER.error("Etherscan API rate limit exceeded")
                 raise InvalidCompilation("Etherscan API rate limit exceeded")


### PR DESCRIPTION
Etherscan now returns the following error message when rate limit is reached `"Max rate limit reached, please use API Key for higher rate limit"`.
https://docs.etherscan.io/support/common-error-messages#max-rate-limit
At the moment when rate limit is reached an incorrect error message is returned.

Closes https://github.com/crytic/crytic-compile/issues/233