### PR TITLE
Do not explicitly pass --force to forge build

### DIFF
--- a/crytic_compile/platform/foundry.py
+++ b/crytic_compile/platform/foundry.py
@@ -55,7 +55,6 @@ class Foundry(AbstractPlatform):
                 "forge",
                 "build",
                 "--build-info",
-                "--force",
             ]
 
             LOGGER.info(


### PR DESCRIPTION
It is still possible to set `force = true` in foundry.toml for projects that need it