### PR TITLE
[Breaking API Change] Use list instead of set for filenames and contracts_names; change filename ordering

### DIFF
--- a/crytic_compile/compilation_unit.py
+++ b/crytic_compile/compilation_unit.py
@@ -7,7 +7,7 @@ At least one compilation unit exists for each version of solc used
 """
 import uuid
 from collections import defaultdict
-from typing import TYPE_CHECKING, Dict, Set, Optional
+from typing import TYPE_CHECKING, Dict, List, Set, Optional
 
 from crytic_compile.compiler.compiler import CompilerVersion
 from crytic_compile.source_unit import SourceUnit
@@ -36,7 +36,7 @@ class CompilationUnit:
         self._source_units: Dict[Filename, SourceUnit] = {}
 
         # set containing all the filenames of this compilation unit
-        self._filenames: Set[Filename] = set()
+        self._filenames: List[Filename] = []
 
         # mapping from absolute/relative/used to filename
         self._filenames_lookup: Optional[Dict[str, Filename]] = None
@@ -114,6 +114,8 @@ class CompilationUnit:
         Create the source unit associated with the filename
         Add the relevant info in the compilation unit/crytic compile
         If the source unit already exist, return it
+        Also appends filename to the end of filenames, if not already present
+        So this function should be called in the order you want filenames to have
 
         Args:
             filename (Filename): filename of the source unit
@@ -123,8 +125,9 @@ class CompilationUnit:
         """
         if not filename in self._source_units:
             source_unit = SourceUnit(self, filename)  # type: ignore
-            self.filenames.add(filename)
             self._source_units[filename] = source_unit
+            if filename not in self.filenames:
+                self.filenames.append(filename)
         return self._source_units[filename]
 
     # endregion
@@ -135,20 +138,20 @@ class CompilationUnit:
     ###################################################################################
 
     @property
-    def filenames(self) -> Set[Filename]:
+    def filenames(self) -> List[Filename]:
         """Return the filenames used by the compilation unit
 
         Returns:
-            Set[Filename]: Filenames used by the compilation units
+            list[Filename]: Filenames used by the compilation units
         """
         return self._filenames
 
     @filenames.setter
-    def filenames(self, all_filenames: Set[Filename]) -> None:
+    def filenames(self, all_filenames: List[Filename]) -> None:
         """Set the filenames
 
         Args:
-            all_filenames (Set[Filename]): new filenames
+            all_filenames (List[Filename]): new filenames
         """
         self._filenames = all_filenames
 

--- a/crytic_compile/crytic_compile.py
+++ b/crytic_compile/crytic_compile.py
@@ -170,16 +170,16 @@ class CryticCompile:
     ###################################################################################
     ###################################################################################
     @property
-    def filenames(self) -> Set[Filename]:
+    def filenames(self) -> List[Filename]:
         """
-        Return the set of all the filenames used
+        Return the list of all the filenames used
 
         Returns:
-             Set[Filename]: list of filenames
+             List[Filename]: list of filenames
         """
-        filenames: Set[Filename] = set()
+        filenames: List[Filename] = []
         for compile_unit in self._compilation_units.values():
-            filenames = filenames.union(compile_unit.filenames)
+            filenames = filenames + compile_unit.filenames
         return filenames
 
     def filename_lookup(self, filename: str) -> Filename:

--- a/crytic_compile/platform/brownie.py
+++ b/crytic_compile/platform/brownie.py
@@ -181,7 +181,7 @@ def _iterate_over_files(
 
             compilation_unit.filename_to_contracts[filename].add(contract_name)
 
-            source_unit.contracts_names.add(contract_name)
+            source_unit.add_contract_name(contract_name)
             source_unit.abis[contract_name] = target_loaded["abi"]
             source_unit.bytecodes_init[contract_name] = target_loaded["bytecode"].replace("0x", "")
             source_unit.bytecodes_runtime[contract_name] = target_loaded[

--- a/crytic_compile/platform/buidler.py
+++ b/crytic_compile/platform/buidler.py
@@ -111,46 +111,6 @@ class Buidler(AbstractPlatform):
         with open(target_solc_file, encoding="utf8") as file_desc:
             targets_json = json.load(file_desc)
 
-            if "contracts" in targets_json:
-                for original_filename, contracts_info in targets_json["contracts"].items():
-                    filename = convert_filename(
-                        original_filename,
-                        relative_to_short,
-                        crytic_compile,
-                        working_dir=buidler_working_dir,
-                    )
-                    source_unit = compilation_unit.create_source_unit(filename)
-
-                    for original_contract_name, info in contracts_info.items():
-                        contract_name = extract_name(original_contract_name)
-
-                        if (
-                            original_filename.startswith("ontracts/")
-                            and not skip_directory_name_fix
-                        ):
-                            original_filename = "c" + original_filename
-
-                        source_unit.contracts_names.add(contract_name)
-                        compilation_unit.filename_to_contracts[filename].add(contract_name)
-
-                        source_unit.abis[contract_name] = info["abi"]
-                        source_unit.bytecodes_init[contract_name] = info["evm"]["bytecode"][
-                            "object"
-                        ]
-                        source_unit.bytecodes_runtime[contract_name] = info["evm"][
-                            "deployedBytecode"
-                        ]["object"]
-                        source_unit.srcmaps_init[contract_name] = info["evm"]["bytecode"][
-                            "sourceMap"
-                        ].split(";")
-                        source_unit.srcmaps_runtime[contract_name] = info["evm"][
-                            "deployedBytecode"
-                        ]["sourceMap"].split(";")
-                        userdoc = info.get("userdoc", {})
-                        devdoc = info.get("devdoc", {})
-                        natspec = Natspec(userdoc, devdoc)
-                        source_unit.natspec[contract_name] = natspec
-
             if "sources" in targets_json:
                 for path, info in targets_json["sources"].items():
 
@@ -170,6 +130,46 @@ class Buidler(AbstractPlatform):
                         )
                     source_unit = compilation_unit.create_source_unit(path)
                     source_unit.ast = info["ast"]
+
+            if "contracts" in targets_json:
+                for original_filename, contracts_info in targets_json["contracts"].items():
+                    filename = convert_filename(
+                        original_filename,
+                        relative_to_short,
+                        crytic_compile,
+                        working_dir=buidler_working_dir,
+                    )
+                    source_unit = compilation_unit.create_source_unit(filename)
+
+                    for original_contract_name, info in contracts_info.items():
+                        contract_name = extract_name(original_contract_name)
+
+                        if (
+                            original_filename.startswith("ontracts/")
+                            and not skip_directory_name_fix
+                        ):
+                            original_filename = "c" + original_filename
+
+                        source_unit.add_contract_name(contract_name)
+                        compilation_unit.filename_to_contracts[filename].add(contract_name)
+
+                        source_unit.abis[contract_name] = info["abi"]
+                        source_unit.bytecodes_init[contract_name] = info["evm"]["bytecode"][
+                            "object"
+                        ]
+                        source_unit.bytecodes_runtime[contract_name] = info["evm"][
+                            "deployedBytecode"
+                        ]["object"]
+                        source_unit.srcmaps_init[contract_name] = info["evm"]["bytecode"][
+                            "sourceMap"
+                        ].split(";")
+                        source_unit.srcmaps_runtime[contract_name] = info["evm"][
+                            "deployedBytecode"
+                        ]["sourceMap"].split(";")
+                        userdoc = info.get("userdoc", {})
+                        devdoc = info.get("devdoc", {})
+                        natspec = Natspec(userdoc, devdoc)
+                        source_unit.natspec[contract_name] = natspec
 
     def clean(self, **kwargs: str) -> None:
         # TODO: call "buldler clean"?

--- a/crytic_compile/platform/dapp.py
+++ b/crytic_compile/platform/dapp.py
@@ -69,6 +69,13 @@ class Dapp(AbstractPlatform):
             if "version" in targets_json:
                 version = re.findall(r"\d+\.\d+\.\d+", targets_json["version"])[0]
 
+            for path, info in targets_json["sources"].items():
+                path = convert_filename(
+                    path, _relative_to_short, crytic_compile, working_dir=self._target
+                )
+                source_unit = compilation_unit.create_source_unit(path)
+                source_unit.ast = info["ast"]
+
             for original_filename, contracts_info in targets_json["contracts"].items():
 
                 filename = convert_filename(
@@ -87,7 +94,7 @@ class Dapp(AbstractPlatform):
                         ):
                             optimized |= metadata["settings"]["optimizer"]["enabled"]
                     contract_name = extract_name(original_contract_name)
-                    source_unit.contracts_names.add(contract_name)
+                    source_unit.add_contract_name(contract_name)
                     compilation_unit.filename_to_contracts[filename].add(contract_name)
 
                     source_unit.abis[contract_name] = info["abi"]
@@ -109,13 +116,6 @@ class Dapp(AbstractPlatform):
                     if version is None:
                         metadata = json.loads(info["metadata"])
                         version = re.findall(r"\d+\.\d+\.\d+", metadata["compiler"]["version"])[0]
-
-            for path, info in targets_json["sources"].items():
-                path = convert_filename(
-                    path, _relative_to_short, crytic_compile, working_dir=self._target
-                )
-                source_unit = compilation_unit.create_source_unit(path)
-                source_unit.ast = info["ast"]
 
         compilation_unit.compiler_version = CompilerVersion(
             compiler="solc", version=version, optimized=optimized

--- a/crytic_compile/platform/embark.py
+++ b/crytic_compile/platform/embark.py
@@ -120,6 +120,15 @@ class Embark(AbstractPlatform):
 
         with open(infile, "r", encoding="utf8") as file_desc:
             targets_loaded = json.load(file_desc)
+
+            if "sources" in targets_loaded:
+                compilation_unit.filenames = [
+                    convert_filename(
+                        path, _relative_to_short, crytic_compile, working_dir=self._target
+                    )
+                    for path in targets_loaded["sources"]
+                ]
+
             for k, ast in targets_loaded["asts"].items():
                 filename = convert_filename(
                     k, _relative_to_short, crytic_compile, working_dir=self._target
@@ -147,7 +156,7 @@ class Embark(AbstractPlatform):
                 source_unit = compilation_unit.create_source_unit(filename)
 
                 compilation_unit.filename_to_contracts[filename].add(contract_name)
-                source_unit.contracts_names.add(contract_name)
+                source_unit.add_contract_name(contract_name)
 
                 if "abi" in info:
                     source_unit.abis[contract_name] = info["abi"]

--- a/crytic_compile/platform/etherlime.py
+++ b/crytic_compile/platform/etherlime.py
@@ -137,7 +137,7 @@ class Etherlime(AbstractPlatform):
                 contract_name = target_loaded["contractName"]
 
                 compilation_unit.filename_to_contracts[filename].add(contract_name)
-                source_unit.contracts_names.add(contract_name)
+                source_unit.add_contract_name(contract_name)
                 source_unit.abis[contract_name] = target_loaded["abi"]
                 source_unit.bytecodes_init[contract_name] = target_loaded["bytecode"].replace(
                     "0x", ""

--- a/crytic_compile/platform/etherscan.py
+++ b/crytic_compile/platform/etherscan.py
@@ -79,7 +79,7 @@ def _handle_bytecode(crytic_compile: "CryticCompile", target: str, result_b: byt
 
     source_unit = compilation_unit.create_source_unit(contract_filename)
 
-    source_unit.contracts_names.add(contract_name)
+    source_unit.add_contract_name(contract_name)
     compilation_unit.filename_to_contracts[contract_filename].add(contract_name)
     source_unit.abis[contract_name] = {}
     source_unit.bytecodes_init[contract_name] = bytecode

--- a/crytic_compile/platform/hardhat.py
+++ b/crytic_compile/platform/hardhat.py
@@ -78,42 +78,6 @@ def hardhat_like_parsing(
                 f"0.4.{x}" for x in range(0, 10)
             ]
 
-            if "contracts" in targets_json:
-                for original_filename, contracts_info in targets_json["contracts"].items():
-
-                    filename = convert_filename(
-                        original_filename,
-                        relative_to_short,
-                        crytic_compile,
-                        working_dir=working_dir,
-                    )
-
-                    source_unit = compilation_unit.create_source_unit(filename)
-
-                    for original_contract_name, info in contracts_info.items():
-                        contract_name = extract_name(original_contract_name)
-
-                        source_unit.contracts_names.add(contract_name)
-                        compilation_unit.filename_to_contracts[filename].add(contract_name)
-
-                        source_unit.abis[contract_name] = info["abi"]
-                        source_unit.bytecodes_init[contract_name] = info["evm"]["bytecode"][
-                            "object"
-                        ]
-                        source_unit.bytecodes_runtime[contract_name] = info["evm"][
-                            "deployedBytecode"
-                        ]["object"]
-                        source_unit.srcmaps_init[contract_name] = info["evm"]["bytecode"][
-                            "sourceMap"
-                        ].split(";")
-                        source_unit.srcmaps_runtime[contract_name] = info["evm"][
-                            "deployedBytecode"
-                        ]["sourceMap"].split(";")
-                        userdoc = info.get("userdoc", {})
-                        devdoc = info.get("devdoc", {})
-                        natspec = Natspec(userdoc, devdoc)
-                        source_unit.natspec[contract_name] = natspec
-
             if "sources" in targets_json:
                 for path, info in targets_json["sources"].items():
                     if skip_filename:
@@ -133,6 +97,42 @@ def hardhat_like_parsing(
 
                     source_unit = compilation_unit.create_source_unit(path)
                     source_unit.ast = info["ast"]
+
+            if "contracts" in targets_json:
+                for original_filename, contracts_info in targets_json["contracts"].items():
+
+                    filename = convert_filename(
+                        original_filename,
+                        relative_to_short,
+                        crytic_compile,
+                        working_dir=working_dir,
+                    )
+
+                    source_unit = compilation_unit.create_source_unit(filename)
+
+                    for original_contract_name, info in contracts_info.items():
+                        contract_name = extract_name(original_contract_name)
+
+                        source_unit.add_contract_name(contract_name)
+                        compilation_unit.filename_to_contracts[filename].add(contract_name)
+
+                        source_unit.abis[contract_name] = info["abi"]
+                        source_unit.bytecodes_init[contract_name] = info["evm"]["bytecode"][
+                            "object"
+                        ]
+                        source_unit.bytecodes_runtime[contract_name] = info["evm"][
+                            "deployedBytecode"
+                        ]["object"]
+                        source_unit.srcmaps_init[contract_name] = info["evm"]["bytecode"][
+                            "sourceMap"
+                        ].split(";")
+                        source_unit.srcmaps_runtime[contract_name] = info["evm"][
+                            "deployedBytecode"
+                        ]["sourceMap"].split(";")
+                        userdoc = info.get("userdoc", {})
+                        devdoc = info.get("devdoc", {})
+                        natspec = Natspec(userdoc, devdoc)
+                        source_unit.natspec[contract_name] = natspec
 
 
 class Hardhat(AbstractPlatform):

--- a/crytic_compile/platform/solc.py
+++ b/crytic_compile/platform/solc.py
@@ -76,13 +76,6 @@ def export_to_solc_from_compilation_unit(
     sources = {filename: {"AST": ast} for (filename, ast) in compilation_unit.asts.items()}
     source_list = [x.absolute for x in compilation_unit.filenames]
 
-    # needed for Echidna, see https://github.com/crytic/crytic-compile/issues/112
-    first_source_list = list(filter(lambda f: "@" in f, source_list))
-    second_source_list = list(filter(lambda f: "@" not in f, source_list))
-    first_source_list.sort()
-    second_source_list.sort()
-    source_list = first_source_list + second_source_list
-
     # Create our root object to contain the contracts and other information.
     output = {"sources": sources, "sourceList": source_list, "contracts": contracts}
 
@@ -163,10 +156,6 @@ class Solc(AbstractPlatform):
             f"0.4.{x}" for x in range(0, 10)
         ]
 
-        solc_handle_contracts(
-            targets_json, skip_filename, compilation_unit, self._target, solc_working_dir
-        )
-
         if "sources" in targets_json:
             for path, info in targets_json["sources"].items():
                 if skip_filename:
@@ -182,6 +171,10 @@ class Solc(AbstractPlatform):
                     )
                 source_unit = compilation_unit.create_source_unit(path)
                 source_unit.ast = info["AST"]
+
+        solc_handle_contracts(
+            targets_json, skip_filename, compilation_unit, self._target, solc_working_dir
+        )
 
     def clean(self, **_kwargs: str) -> None:
         """Clean compilation artifacts
@@ -334,7 +327,7 @@ def solc_handle_contracts(
 
             source_unit = compilation_unit.create_source_unit(filename)
 
-            source_unit.contracts_names.add(contract_name)
+            source_unit.add_contract_name(contract_name)
             compilation_unit.filename_to_contracts[filename].add(contract_name)
             source_unit.abis[contract_name] = (
                 json.loads(info["abi"]) if not is_above_0_8 else info["abi"]

--- a/crytic_compile/platform/solc_standard_json.py
+++ b/crytic_compile/platform/solc_standard_json.py
@@ -261,6 +261,26 @@ def parse_standard_json_output(
 
     skip_filename = compilation_unit.compiler_version.version in [f"0.4.{x}" for x in range(0, 10)]
 
+    if "sources" in targets_json:
+        for path, info in targets_json["sources"].items():
+            if skip_filename:
+                path = convert_filename(
+                    path,
+                    relative_to_short,
+                    compilation_unit.crytic_compile,
+                    working_dir=solc_working_dir,
+                )
+            else:
+                path = convert_filename(
+                    path,
+                    relative_to_short,
+                    compilation_unit.crytic_compile,
+                    working_dir=solc_working_dir,
+                )
+            source_unit = compilation_unit.create_source_unit(path)
+
+            source_unit.ast = info.get("ast")
+
     if "contracts" in targets_json:
         for file_path, file_contracts in targets_json["contracts"].items():
             for contract_name, info in file_contracts.items():
@@ -282,7 +302,7 @@ def parse_standard_json_output(
 
                 source_unit = compilation_unit.create_source_unit(filename)
 
-                source_unit.contracts_names.add(contract_name)
+                source_unit.add_contract_name(contract_name)
                 compilation_unit.filename_to_contracts[filename].add(contract_name)
                 source_unit.abis[contract_name] = info["abi"]
 
@@ -301,26 +321,6 @@ def parse_standard_json_output(
                 source_unit.srcmaps_runtime[contract_name] = info["evm"]["deployedBytecode"][
                     "sourceMap"
                 ].split(";")
-
-    if "sources" in targets_json:
-        for path, info in targets_json["sources"].items():
-            if skip_filename:
-                path = convert_filename(
-                    path,
-                    relative_to_short,
-                    compilation_unit.crytic_compile,
-                    working_dir=solc_working_dir,
-                )
-            else:
-                path = convert_filename(
-                    path,
-                    relative_to_short,
-                    compilation_unit.crytic_compile,
-                    working_dir=solc_working_dir,
-                )
-            source_unit = compilation_unit.create_source_unit(path)
-
-            source_unit.ast = info.get("ast")
 
 
 # Inherits is_dependency/is_supported from Solc

--- a/crytic_compile/platform/truffle.py
+++ b/crytic_compile/platform/truffle.py
@@ -251,7 +251,7 @@ class Truffle(AbstractPlatform):
                 contract_name = target_loaded["contractName"]
                 source_unit.natspec[contract_name] = natspec
                 compilation_unit.filename_to_contracts[filename].add(contract_name)
-                source_unit.contracts_names.add(contract_name)
+                source_unit.add_contract_name(contract_name)
                 source_unit.abis[contract_name] = target_loaded["abi"]
                 source_unit.bytecodes_init[contract_name] = target_loaded["bytecode"].replace(
                     "0x", ""

--- a/crytic_compile/platform/vyper.py
+++ b/crytic_compile/platform/vyper.py
@@ -62,7 +62,7 @@ class Vyper(AbstractPlatform):
 
         source_unit = compilation_unit.create_source_unit(filename)
 
-        source_unit.contracts_names.add(contract_name)
+        source_unit.add_contract_name(contract_name)
         compilation_unit.filename_to_contracts[filename].add(contract_name)
         source_unit.abis[contract_name] = info["abi"]
         source_unit.bytecodes_init[contract_name] = info["bytecode"].replace("0x", "")

--- a/crytic_compile/platform/waffle.py
+++ b/crytic_compile/platform/waffle.py
@@ -181,6 +181,12 @@ class Waffle(AbstractPlatform):
 
         compilation_unit = CompilationUnit(crytic_compile, str(target))
 
+        if "sources" in target_all:
+            compilation_unit.filenames = [
+                convert_filename(path, _relative_to_short, crytic_compile, working_dir=target)
+                for path in target_all["sources"]
+            ]
+
         for contract in target_all["contracts"]:
             target_loaded = target_all["contracts"][contract]
             contract = contract.split(":")
@@ -192,9 +198,8 @@ class Waffle(AbstractPlatform):
             source_unit = compilation_unit.create_source_unit(filename)
 
             source_unit.ast = target_all["sources"][contract[0]]["AST"]
-            compilation_unit.filenames.add(filename)
             compilation_unit.filename_to_contracts[filename].add(contract_name)
-            source_unit.contracts_names.add(contract_name)
+            source_unit.add_contract_name(contract_name)
             source_unit.abis[contract_name] = target_loaded["abi"]
 
             userdoc = target_loaded.get("userdoc", {})

--- a/crytic_compile/source_unit.py
+++ b/crytic_compile/source_unit.py
@@ -4,7 +4,7 @@ Each source unit represents one file so may be associated with
 One or more source units are associated with each compilation unit
 """
 import re
-from typing import Dict, List, Optional, Union, Tuple, Set, TYPE_CHECKING
+from typing import Dict, List, Optional, Union, Tuple, TYPE_CHECKING
 import cbor2
 
 from Crypto.Hash import keccak
@@ -87,10 +87,10 @@ class SourceUnit:
         self._libraries: Dict[str, List[Tuple[str, str]]] = {}
 
         # set containing all the contract names
-        self._contracts_name: Set[str] = set()
+        self._contracts_name: List[str] = []
 
         # set containing all the contract name without the libraries
-        self._contracts_name_without_libraries: Optional[Set[str]] = None
+        self._contracts_name_without_libraries: Optional[List[str]] = None
 
     # region ABI
     ###################################################################################
@@ -411,37 +411,46 @@ class SourceUnit:
     ###################################################################################
 
     @property
-    def contracts_names(self) -> Set[str]:
+    def contracts_names(self) -> List[str]:
         """Return the contracts names
 
         Returns:
-            Set[str]: List of the contracts names
+            List[str]: List of the contracts names
         """
         return self._contracts_name
 
     @contracts_names.setter
-    def contracts_names(self, names: Set[str]) -> None:
+    def contracts_names(self, names: List[str]) -> None:
         """Set the contract names
 
         Args:
-            names (Set[str]): New contracts names
+            names (List[str]): New contracts names
         """
         self._contracts_name = names
 
+    def add_contract_name(self, name: str) -> None:
+        """Add name to contracts_names, if not already present
+
+        Args:
+            name (str): Name to add to the list
+        """
+        if name not in self.contracts_names:
+            self.contracts_names.append(name)
+
     @property
-    def contracts_names_without_libraries(self) -> Set[str]:
+    def contracts_names_without_libraries(self) -> List[str]:
         """Return the contracts names without the librairies
 
         Returns:
-            Set[str]: List of contracts
+            List[str]: List of contracts
         """
         if self._contracts_name_without_libraries is None:
             libraries: List[str] = []
             for contract_name in self._contracts_name:
                 libraries += self.libraries_names(contract_name)
-            self._contracts_name_without_libraries = {
+            self._contracts_name_without_libraries = [
                 l for l in self._contracts_name if l not in set(libraries)
-            }
+            ]
         return self._contracts_name_without_libraries
 
     # endregion


### PR DESCRIPTION
(See bolded for TODOs that I could use some advice on)

This PR:
- Uses lists instead of sets for `filenames` and `contracts_names`.
- Changes code for each platform so that `filenames` is ordered in the same way as `targets_json["sources"]`. In waffle and embark, this results in new code. Otherwise it's just moving code around.
- Deletes redundant code in embark and `platform/standard.py` that added filenames to the list.

It fixes:
- `source_list` being ordered differently than the source list outputted by the compiler, resulting in source maps being incorrect, resulting in echidna producing bad coverage reports.
- Contracts list being ordered differently each time, resulting in nondeterministic outputs

Testing:
- Tested with hardhat on multiple projects, including projects where the current version of crytic_compile works correctly with echidna and projects where it works incorrectly with echidna (incorrect ordering of filenames, producing bad coverage).
- Tested on a hardhat project with multiple versions of hardhat (2.1, 2.8, 2.14).
- Tested on a forge project where the current version of crytic_compile works incorrectly with echidna.
- Tested on an example waffle project, since I added a few lines to waffle.py instead of just moving things around
- Intended to test on embark since I added and removed a few lines there, but **couldn't install embark in order to test it. Tried on Mac, NixOS, and WSL running Ubuntu. Help/advice here would be appreciated.** I don't think testing here outside of CI tests is strictly necessary since I can't see any way my new code *breaks* anything that wouldn't be caught by CI; the only possibility seems to be that `targets_loaded["sources"]` doesn't exist and my new code never gets called, resulting in filenames potentially having the wrong order.
- **Haven't tested out other frameworks yet. Should I go through them one by one, installing and making projects and crytic-compiling? Should I just trust the CI to catch any bugs?** In general, code is mostly moved around rather than being rewritten, so I'd imagine that there aren't any deep bugs that CI couldn't catch.