### PR TITLE
increase observability and provide suggestions/clearer errors

### DIFF
--- a/crytic_compile/platform/foundry.py
+++ b/crytic_compile/platform/foundry.py
@@ -51,34 +51,14 @@ class Foundry(AbstractPlatform):
             )
 
         if not ignore_compile:
-            cmd = [
-                "forge",
-                "build",
-                "--build-info",
-            ]
-
-            LOGGER.info(
-                "'%s' running",
-                " ".join(cmd),
-            )
-
-            with subprocess.Popen(
-                cmd,
-                stdout=subprocess.PIPE,
-                stderr=subprocess.PIPE,
+            run(
+                [
+                    "forge",
+                    "build",
+                    "--build-info",
+                ],
                 cwd=self._target,
-                executable=shutil.which(cmd[0]),
-            ) as process:
-
-                stdout_bytes, stderr_bytes = process.communicate()
-                stdout, stderr = (
-                    stdout_bytes.decode(errors="backslashreplace"),
-                    stderr_bytes.decode(errors="backslashreplace"),
-                )  # convert bytestrings to unicode strings
-
-                LOGGER.info(stdout)
-                if stderr:
-                    LOGGER.error(stderr)
+            )
 
         build_directory = Path(
             self._target,

--- a/crytic_compile/platform/foundry.py
+++ b/crytic_compile/platform/foundry.py
@@ -3,8 +3,6 @@ Foundry platform
 """
 import logging
 import os
-import shutil
-import subprocess
 from pathlib import Path
 from typing import TYPE_CHECKING, List
 

--- a/crytic_compile/platform/hardhat.py
+++ b/crytic_compile/platform/hardhat.py
@@ -210,9 +210,6 @@ class Hardhat(AbstractPlatform):
 
         # If there is both foundry and hardhat, foundry takes priority
         if os.path.isfile(os.path.join(target, "foundry.toml")):
-            LOGGER.info(
-                "foundry.toml found, ignoring hardhat. To force hardhat, use `--compile-force-framework hardhat`"
-            )
             return False
 
         return os.path.isfile(os.path.join(target, "hardhat.config.js")) | os.path.isfile(

--- a/crytic_compile/platform/hardhat.py
+++ b/crytic_compile/platform/hardhat.py
@@ -4,6 +4,7 @@ Hardhat platform
 import json
 import logging
 import os
+import shutil
 import subprocess
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple, Union

--- a/crytic_compile/platform/hardhat.py
+++ b/crytic_compile/platform/hardhat.py
@@ -4,6 +4,7 @@ Hardhat platform
 import json
 import logging
 import os
+import subprocess
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple, Union
 

--- a/crytic_compile/platform/hardhat.py
+++ b/crytic_compile/platform/hardhat.py
@@ -4,8 +4,6 @@ Hardhat platform
 import json
 import logging
 import os
-import shutil
-import subprocess
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple, Union
 


### PR DESCRIPTION
- use `run` command 
- check if build directory exists explicitly

closes https://github.com/crytic/crytic-compile/issues/437 and closes https://github.com/crytic/crytic-compile/issues/430