### PR TITLE
platform: etherscan: add support for solc remaps, evm version

### DIFF
--- a/crytic_compile/platform/etherscan.py
+++ b/crytic_compile/platform/etherscan.py
@@ -341,8 +341,10 @@ class Etherscan(AbstractPlatform):
         )[0]
 
         # etherscan can report "default" which is not a valid EVM version
-        evm_version: Optional[str] = result.get("EVMVersion", None)
-        evm_version = evm_version if evm_version != "Default" else None
+        evm_version: Optional[str] = None
+        if "EVMVersion" in result:
+            assert isinstance(result["EVMVersion"], str)
+            evm_version = result["EVMVersion"] if result["EVMVersion"] != "Default" else None
 
         optimization_used: bool = result["OptimizationUsed"] == "1"
 

--- a/crytic_compile/platform/etherscan.py
+++ b/crytic_compile/platform/etherscan.py
@@ -458,13 +458,19 @@ def _sanitize_remappings(
             LOGGER.warning("Invalid remapping %s", r)
             continue
 
-        origin, dest = split
+        origin, dest = split[0], Path(split[1])
+
+        # if path is absolute, relativize it
+        if dest.is_absolute():
+            dest = Path(*dest.parts[1:])
+
         dest_disk = Path(allowed_directory, dest)
 
         if os.path.commonpath((allowed_path, os.path.abspath(dest_disk))) != allowed_path:
             LOGGER.warning("Remapping %s=%s is potentially unsafe, skipping", origin, dest)
             continue
 
-        remappings_clean.append(f"{origin}={dest}")
+        # always use a trailing slash for the destination
+        remappings_clean.append(f"{origin}={str(dest / '_')[:-1]}")
 
     return remappings_clean

--- a/crytic_compile/platform/etherscan.py
+++ b/crytic_compile/platform/etherscan.py
@@ -466,11 +466,11 @@ def _sanitize_remappings(
             LOGGER.warning("Invalid remapping %s", r)
             continue
 
-        origin, dest = split[0], Path(split[1])
+        origin, dest = split[0], PurePosixPath(split[1])
 
         # if path is absolute, relativize it
         if dest.is_absolute():
-            dest = Path(*dest.parts[1:])
+            dest = PurePosixPath(*dest.parts[1:])
 
         dest_disk = Path(allowed_directory, dest)
 

--- a/crytic_compile/platform/etherscan.py
+++ b/crytic_compile/platform/etherscan.py
@@ -340,6 +340,10 @@ class Etherscan(AbstractPlatform):
             r"\d+\.\d+\.\d+", _convert_version(result["CompilerVersion"])
         )[0]
 
+        # etherscan can report "default" which is not a valid EVM version
+        evm_version: Optional[str] = result.get("EVMVersion", None)
+        evm_version = evm_version if evm_version != "Default" else None
+
         optimization_used: bool = result["OptimizationUsed"] == "1"
 
         optimize_runs = None
@@ -377,7 +381,11 @@ class Etherscan(AbstractPlatform):
         )
         compilation_unit.compiler_version.look_for_installed_version()
         solc_standard_json.standalone_compile(
-            filenames, compilation_unit, working_dir=working_dir, remappings=remappings
+            filenames,
+            compilation_unit,
+            working_dir=working_dir,
+            remappings=remappings,
+            evm_version=evm_version,
         )
 
     def clean(self, **_kwargs: str) -> None:

--- a/crytic_compile/platform/etherscan.py
+++ b/crytic_compile/platform/etherscan.py
@@ -94,9 +94,6 @@ def _handle_bytecode(crytic_compile: "CryticCompile", target: str, result_b: byt
     crytic_compile.bytecode_only = True
 
 
-# def _etherscan_single_file():
-
-
 def _handle_single_file(
     source_code: str, addr: str, prefix: Optional[str], contract_name: str, export_dir: str
 ) -> str:
@@ -435,15 +432,3 @@ def _convert_version(version: str) -> str:
         str: converted version
     """
     return version[1 : version.find("+")]
-
-
-def _relative_to_short(relative: Path) -> Path:
-    """Translate relative path to short (do nothing for etherscan)
-
-    Args:
-        relative (Path): path to the target
-
-    Returns:
-        Path: Translated path
-    """
-    return relative

--- a/crytic_compile/platform/solc_standard_json.py
+++ b/crytic_compile/platform/solc_standard_json.py
@@ -26,7 +26,10 @@ LOGGER = logging.getLogger("CryticCompile")
 
 
 def standalone_compile(
-    filenames: List[str], compilation_unit: CompilationUnit, working_dir: Optional[str] = None
+    filenames: List[str],
+    compilation_unit: CompilationUnit,
+    working_dir: Optional[str] = None,
+    remappings: Optional[List[str]] = None,
 ) -> None:
     """
     Boilerplate function to run the the standardjson. compilation_unit.compiler_version must be set before calling this function
@@ -42,6 +45,7 @@ def standalone_compile(
         filenames (List[str]): list of the files to compile
         compilation_unit (CompilationUnit): compilation unit object to populate
         working_dir (Optional[str]): working directory
+        remappings (Optional[List[str]]): list of solc remaps to use
 
     Returns:
 
@@ -56,6 +60,10 @@ def standalone_compile(
 
     for filename in filenames:
         add_source_file(standard_json_dict, filename)
+
+    if remappings is not None:
+        for remap in remappings:
+            add_remapping(standard_json_dict, remap)
 
     add_optimization(
         standard_json_dict,

--- a/crytic_compile/platform/solc_standard_json.py
+++ b/crytic_compile/platform/solc_standard_json.py
@@ -30,6 +30,7 @@ def standalone_compile(
     compilation_unit: CompilationUnit,
     working_dir: Optional[str] = None,
     remappings: Optional[List[str]] = None,
+    evm_version: Optional[str] = None,
 ) -> None:
     """
     Boilerplate function to run the the standardjson. compilation_unit.compiler_version must be set before calling this function
@@ -46,6 +47,7 @@ def standalone_compile(
         compilation_unit (CompilationUnit): compilation unit object to populate
         working_dir (Optional[str]): working directory
         remappings (Optional[List[str]]): list of solc remaps to use
+        evm_version (Optional[str]): EVM version to target. None for default
 
     Returns:
 
@@ -64,6 +66,9 @@ def standalone_compile(
     if remappings is not None:
         for remap in remappings:
             add_remapping(standard_json_dict, remap)
+
+    if evm_version is not None:
+        add_evm_version(standard_json_dict, evm_version)
 
     add_optimization(
         standard_json_dict,
@@ -253,6 +258,24 @@ def add_optimization(
             json_dict["settings"]["optimizer"]["runs"] = optimize_runs
         return
     json_dict["settings"]["optimizer"] = {"enabled": False}
+
+
+def add_evm_version(json_dict: Dict, version: str) -> None:
+    """
+    Add the version of the EVM to compile for.
+
+    Can be one of the following values: homestead, tangerineWhistle,
+    spuriousDragon, byzantium, constantinople, petersburg, istanbul,
+    berlin, london or paris
+
+    Args:
+        json_dict (Dict): solc standard json input
+        version (str): the EVM version to target
+
+    Returns:
+
+    """
+    json_dict["settings"]["evmVersion"] = version
 
 
 def parse_standard_json_output(

--- a/scripts/ci_test_etherscan.sh
+++ b/scripts/ci_test_etherscan.sh
@@ -36,3 +36,16 @@ then
     exit 255
 fi
 echo "::endgroup::"
+
+delay_no_key
+
+# From crytic/crytic-compile#415
+echo "::group::Etherscan #4"
+crytic-compile 0x19c7d0fbf906c282dedb5543d098f43dfe9f856f --compile-remove-metadata --etherscan-apikey "$GITHUB_ETHERSCAN"
+
+if [ $? -ne 0 ]
+then
+    echo "Etherscan #4 test failed"
+    exit 255
+fi
+echo "::endgroup::"

--- a/scripts/ci_test_etherscan.sh
+++ b/scripts/ci_test_etherscan.sh
@@ -59,7 +59,14 @@ crytic-compile 0x2a311e451491091d2a1d3c43f4f5744bdb4e773a --compile-remove-metad
 if [ $? -ne 0 ]
 then
     echo "Etherscan #5 test failed"
-    exit 255
+    case "$(uname -sr)" in
+        CYGWIN*|MINGW*|MSYS*)
+            echo "This test is known to fail on Windows"
+        ;;
+        *)
+            exit 255
+        ;;
+    esac
 fi
 echo "::endgroup::"
 

--- a/scripts/ci_test_etherscan.sh
+++ b/scripts/ci_test_etherscan.sh
@@ -62,3 +62,14 @@ then
     exit 255
 fi
 echo "::endgroup::"
+
+# From crytic/crytic-compile#151
+echo "::group::Etherscan #6"
+crytic-compile 0x4c808e3c011514d5016536af11218eec537eb6f5 --compile-remove-metadata --etherscan-apikey "$GITHUB_ETHERSCAN"
+
+if [ $? -ne 0 ]
+then
+    echo "Etherscan #6 test failed"
+    exit 255
+fi
+echo "::endgroup::"

--- a/scripts/ci_test_etherscan.sh
+++ b/scripts/ci_test_etherscan.sh
@@ -49,3 +49,16 @@ then
     exit 255
 fi
 echo "::endgroup::"
+
+delay_no_key
+
+# From crytic/crytic-compile#150
+echo "::group::Etherscan #5"
+crytic-compile 0x2a311e451491091d2a1d3c43f4f5744bdb4e773a --compile-remove-metadata --etherscan-apikey "$GITHUB_ETHERSCAN"
+
+if [ $? -ne 0 ]
+then
+    echo "Etherscan #5 test failed"
+    exit 255
+fi
+echo "::endgroup::"


### PR DESCRIPTION
This adds support for solc remaps and EVM version found in the Etherscan JSON.

Fixes #150, #151, #386, #415