### PR TITLE
Revert "[Breaking API Change] Use list instead of set for filenames and contracts_names; change filename ordering"

### DIFF
--- a/crytic_compile/compilation_unit.py
+++ b/crytic_compile/compilation_unit.py
@@ -7,7 +7,7 @@ At least one compilation unit exists for each version of solc used
 """
 import uuid
 from collections import defaultdict
-from typing import TYPE_CHECKING, Dict, List, Set, Optional
+from typing import TYPE_CHECKING, Dict, Set, Optional
 
 from crytic_compile.compiler.compiler import CompilerVersion
 from crytic_compile.source_unit import SourceUnit
@@ -36,7 +36,7 @@ class CompilationUnit:
         self._source_units: Dict[Filename, SourceUnit] = {}
 
         # set containing all the filenames of this compilation unit
-        self._filenames: List[Filename] = []
+        self._filenames: Set[Filename] = set()
 
         # mapping from absolute/relative/used to filename
         self._filenames_lookup: Optional[Dict[str, Filename]] = None
@@ -114,8 +114,6 @@ class CompilationUnit:
         Create the source unit associated with the filename
         Add the relevant info in the compilation unit/crytic compile
         If the source unit already exist, return it
-        Also appends filename to the end of filenames, if not already present
-        So this function should be called in the order you want filenames to have
 
         Args:
             filename (Filename): filename of the source unit
@@ -125,9 +123,8 @@ class CompilationUnit:
         """
         if not filename in self._source_units:
             source_unit = SourceUnit(self, filename)  # type: ignore
+            self.filenames.add(filename)
             self._source_units[filename] = source_unit
-            if filename not in self.filenames:
-                self.filenames.append(filename)
         return self._source_units[filename]
 
     # endregion
@@ -138,20 +135,20 @@ class CompilationUnit:
     ###################################################################################
 
     @property
-    def filenames(self) -> List[Filename]:
+    def filenames(self) -> Set[Filename]:
         """Return the filenames used by the compilation unit
 
         Returns:
-            list[Filename]: Filenames used by the compilation units
+            Set[Filename]: Filenames used by the compilation units
         """
         return self._filenames
 
     @filenames.setter
-    def filenames(self, all_filenames: List[Filename]) -> None:
+    def filenames(self, all_filenames: Set[Filename]) -> None:
         """Set the filenames
 
         Args:
-            all_filenames (List[Filename]): new filenames
+            all_filenames (Set[Filename]): new filenames
         """
         self._filenames = all_filenames
 

--- a/crytic_compile/crytic_compile.py
+++ b/crytic_compile/crytic_compile.py
@@ -175,11 +175,11 @@ class CryticCompile:
         Return the set of all the filenames used
 
         Returns:
-             Set[Filename]: set of filenames
+             Set[Filename]: list of filenames
         """
         filenames: Set[Filename] = set()
         for compile_unit in self._compilation_units.values():
-            filenames |= set(compile_unit.filenames)
+            filenames = filenames.union(compile_unit.filenames)
         return filenames
 
     def filename_lookup(self, filename: str) -> Filename:

--- a/crytic_compile/platform/brownie.py
+++ b/crytic_compile/platform/brownie.py
@@ -185,7 +185,7 @@ def _iterate_over_files(
 
             compilation_unit.filename_to_contracts[filename].add(contract_name)
 
-            source_unit.add_contract_name(contract_name)
+            source_unit.contracts_names.add(contract_name)
             source_unit.abis[contract_name] = target_loaded["abi"]
             source_unit.bytecodes_init[contract_name] = target_loaded["bytecode"].replace("0x", "")
             source_unit.bytecodes_runtime[contract_name] = target_loaded[

--- a/crytic_compile/platform/buidler.py
+++ b/crytic_compile/platform/buidler.py
@@ -111,26 +111,6 @@ class Buidler(AbstractPlatform):
         with open(target_solc_file, encoding="utf8") as file_desc:
             targets_json = json.load(file_desc)
 
-            if "sources" in targets_json:
-                for path, info in targets_json["sources"].items():
-
-                    if path.startswith("ontracts/") and not skip_directory_name_fix:
-                        path = "c" + path
-
-                    if skip_filename:
-                        path = convert_filename(
-                            self._target,
-                            relative_to_short,
-                            crytic_compile,
-                            working_dir=buidler_working_dir,
-                        )
-                    else:
-                        path = convert_filename(
-                            path, relative_to_short, crytic_compile, working_dir=buidler_working_dir
-                        )
-                    source_unit = compilation_unit.create_source_unit(path)
-                    source_unit.ast = info["ast"]
-
             if "contracts" in targets_json:
                 for original_filename, contracts_info in targets_json["contracts"].items():
                     filename = convert_filename(
@@ -150,7 +130,7 @@ class Buidler(AbstractPlatform):
                         ):
                             original_filename = "c" + original_filename
 
-                        source_unit.add_contract_name(contract_name)
+                        source_unit.contracts_names.add(contract_name)
                         compilation_unit.filename_to_contracts[filename].add(contract_name)
 
                         source_unit.abis[contract_name] = info["abi"]
@@ -170,6 +150,26 @@ class Buidler(AbstractPlatform):
                         devdoc = info.get("devdoc", {})
                         natspec = Natspec(userdoc, devdoc)
                         source_unit.natspec[contract_name] = natspec
+
+            if "sources" in targets_json:
+                for path, info in targets_json["sources"].items():
+
+                    if path.startswith("ontracts/") and not skip_directory_name_fix:
+                        path = "c" + path
+
+                    if skip_filename:
+                        path = convert_filename(
+                            self._target,
+                            relative_to_short,
+                            crytic_compile,
+                            working_dir=buidler_working_dir,
+                        )
+                    else:
+                        path = convert_filename(
+                            path, relative_to_short, crytic_compile, working_dir=buidler_working_dir
+                        )
+                    source_unit = compilation_unit.create_source_unit(path)
+                    source_unit.ast = info["ast"]
 
     def clean(self, **kwargs: str) -> None:
         # TODO: call "buldler clean"?

--- a/crytic_compile/platform/dapp.py
+++ b/crytic_compile/platform/dapp.py
@@ -69,13 +69,6 @@ class Dapp(AbstractPlatform):
             if "version" in targets_json:
                 version = re.findall(r"\d+\.\d+\.\d+", targets_json["version"])[0]
 
-            for path, info in targets_json["sources"].items():
-                path = convert_filename(
-                    path, _relative_to_short, crytic_compile, working_dir=self._target
-                )
-                source_unit = compilation_unit.create_source_unit(path)
-                source_unit.ast = info["ast"]
-
             for original_filename, contracts_info in targets_json["contracts"].items():
 
                 filename = convert_filename(
@@ -94,7 +87,7 @@ class Dapp(AbstractPlatform):
                         ):
                             optimized |= metadata["settings"]["optimizer"]["enabled"]
                     contract_name = extract_name(original_contract_name)
-                    source_unit.add_contract_name(contract_name)
+                    source_unit.contracts_names.add(contract_name)
                     compilation_unit.filename_to_contracts[filename].add(contract_name)
 
                     source_unit.abis[contract_name] = info["abi"]
@@ -116,6 +109,13 @@ class Dapp(AbstractPlatform):
                     if version is None:
                         metadata = json.loads(info["metadata"])
                         version = re.findall(r"\d+\.\d+\.\d+", metadata["compiler"]["version"])[0]
+
+            for path, info in targets_json["sources"].items():
+                path = convert_filename(
+                    path, _relative_to_short, crytic_compile, working_dir=self._target
+                )
+                source_unit = compilation_unit.create_source_unit(path)
+                source_unit.ast = info["ast"]
 
         compilation_unit.compiler_version = CompilerVersion(
             compiler="solc", version=version, optimized=optimized

--- a/crytic_compile/platform/embark.py
+++ b/crytic_compile/platform/embark.py
@@ -120,15 +120,6 @@ class Embark(AbstractPlatform):
 
         with open(infile, "r", encoding="utf8") as file_desc:
             targets_loaded = json.load(file_desc)
-
-            if "sources" in targets_loaded:
-                compilation_unit.filenames = [
-                    convert_filename(
-                        path, _relative_to_short, crytic_compile, working_dir=self._target
-                    )
-                    for path in targets_loaded["sources"]
-                ]
-
             for k, ast in targets_loaded["asts"].items():
                 filename = convert_filename(
                     k, _relative_to_short, crytic_compile, working_dir=self._target
@@ -156,7 +147,7 @@ class Embark(AbstractPlatform):
                 source_unit = compilation_unit.create_source_unit(filename)
 
                 compilation_unit.filename_to_contracts[filename].add(contract_name)
-                source_unit.add_contract_name(contract_name)
+                source_unit.contracts_names.add(contract_name)
 
                 if "abi" in info:
                     source_unit.abis[contract_name] = info["abi"]

--- a/crytic_compile/platform/etherlime.py
+++ b/crytic_compile/platform/etherlime.py
@@ -137,7 +137,7 @@ class Etherlime(AbstractPlatform):
                 contract_name = target_loaded["contractName"]
 
                 compilation_unit.filename_to_contracts[filename].add(contract_name)
-                source_unit.add_contract_name(contract_name)
+                source_unit.contracts_names.add(contract_name)
                 source_unit.abis[contract_name] = target_loaded["abi"]
                 source_unit.bytecodes_init[contract_name] = target_loaded["bytecode"].replace(
                     "0x", ""

--- a/crytic_compile/platform/etherscan.py
+++ b/crytic_compile/platform/etherscan.py
@@ -79,7 +79,7 @@ def _handle_bytecode(crytic_compile: "CryticCompile", target: str, result_b: byt
 
     source_unit = compilation_unit.create_source_unit(contract_filename)
 
-    source_unit.add_contract_name(contract_name)
+    source_unit.contracts_names.add(contract_name)
     compilation_unit.filename_to_contracts[contract_filename].add(contract_name)
     source_unit.abis[contract_name] = {}
     source_unit.bytecodes_init[contract_name] = bytecode

--- a/crytic_compile/platform/hardhat.py
+++ b/crytic_compile/platform/hardhat.py
@@ -78,26 +78,6 @@ def hardhat_like_parsing(
                 f"0.4.{x}" for x in range(0, 10)
             ]
 
-            if "sources" in targets_json:
-                for path, info in targets_json["sources"].items():
-                    if skip_filename:
-                        path = convert_filename(
-                            target,
-                            relative_to_short,
-                            crytic_compile,
-                            working_dir=working_dir,
-                        )
-                    else:
-                        path = convert_filename(
-                            path,
-                            relative_to_short,
-                            crytic_compile,
-                            working_dir=working_dir,
-                        )
-
-                    source_unit = compilation_unit.create_source_unit(path)
-                    source_unit.ast = info["ast"]
-
             if "contracts" in targets_json:
                 for original_filename, contracts_info in targets_json["contracts"].items():
 
@@ -113,7 +93,7 @@ def hardhat_like_parsing(
                     for original_contract_name, info in contracts_info.items():
                         contract_name = extract_name(original_contract_name)
 
-                        source_unit.add_contract_name(contract_name)
+                        source_unit.contracts_names.add(contract_name)
                         compilation_unit.filename_to_contracts[filename].add(contract_name)
 
                         source_unit.abis[contract_name] = info["abi"]
@@ -133,6 +113,26 @@ def hardhat_like_parsing(
                         devdoc = info.get("devdoc", {})
                         natspec = Natspec(userdoc, devdoc)
                         source_unit.natspec[contract_name] = natspec
+
+            if "sources" in targets_json:
+                for path, info in targets_json["sources"].items():
+                    if skip_filename:
+                        path = convert_filename(
+                            target,
+                            relative_to_short,
+                            crytic_compile,
+                            working_dir=working_dir,
+                        )
+                    else:
+                        path = convert_filename(
+                            path,
+                            relative_to_short,
+                            crytic_compile,
+                            working_dir=working_dir,
+                        )
+
+                    source_unit = compilation_unit.create_source_unit(path)
+                    source_unit.ast = info["ast"]
 
 
 class Hardhat(AbstractPlatform):

--- a/crytic_compile/platform/solc.py
+++ b/crytic_compile/platform/solc.py
@@ -76,6 +76,13 @@ def export_to_solc_from_compilation_unit(
     sources = {filename: {"AST": ast} for (filename, ast) in compilation_unit.asts.items()}
     source_list = [x.absolute for x in compilation_unit.filenames]
 
+    # needed for Echidna, see https://github.com/crytic/crytic-compile/issues/112
+    first_source_list = list(filter(lambda f: "@" in f, source_list))
+    second_source_list = list(filter(lambda f: "@" not in f, source_list))
+    first_source_list.sort()
+    second_source_list.sort()
+    source_list = first_source_list + second_source_list
+
     # Create our root object to contain the contracts and other information.
     output = {"sources": sources, "sourceList": source_list, "contracts": contracts}
 
@@ -156,6 +163,10 @@ class Solc(AbstractPlatform):
             f"0.4.{x}" for x in range(0, 10)
         ]
 
+        solc_handle_contracts(
+            targets_json, skip_filename, compilation_unit, self._target, solc_working_dir
+        )
+
         if "sources" in targets_json:
             for path, info in targets_json["sources"].items():
                 if skip_filename:
@@ -171,10 +182,6 @@ class Solc(AbstractPlatform):
                     )
                 source_unit = compilation_unit.create_source_unit(path)
                 source_unit.ast = info["AST"]
-
-        solc_handle_contracts(
-            targets_json, skip_filename, compilation_unit, self._target, solc_working_dir
-        )
 
     def clean(self, **_kwargs: str) -> None:
         """Clean compilation artifacts
@@ -327,7 +334,7 @@ def solc_handle_contracts(
 
             source_unit = compilation_unit.create_source_unit(filename)
 
-            source_unit.add_contract_name(contract_name)
+            source_unit.contracts_names.add(contract_name)
             compilation_unit.filename_to_contracts[filename].add(contract_name)
             source_unit.abis[contract_name] = (
                 json.loads(info["abi"]) if not is_above_0_8 else info["abi"]

--- a/crytic_compile/platform/solc_standard_json.py
+++ b/crytic_compile/platform/solc_standard_json.py
@@ -265,26 +265,6 @@ def parse_standard_json_output(
 
     skip_filename = compilation_unit.compiler_version.version in [f"0.4.{x}" for x in range(0, 10)]
 
-    if "sources" in targets_json:
-        for path, info in targets_json["sources"].items():
-            if skip_filename:
-                path = convert_filename(
-                    path,
-                    relative_to_short,
-                    compilation_unit.crytic_compile,
-                    working_dir=solc_working_dir,
-                )
-            else:
-                path = convert_filename(
-                    path,
-                    relative_to_short,
-                    compilation_unit.crytic_compile,
-                    working_dir=solc_working_dir,
-                )
-            source_unit = compilation_unit.create_source_unit(path)
-
-            source_unit.ast = info.get("ast")
-
     if "contracts" in targets_json:
         for file_path, file_contracts in targets_json["contracts"].items():
             for contract_name, info in file_contracts.items():
@@ -306,7 +286,7 @@ def parse_standard_json_output(
 
                 source_unit = compilation_unit.create_source_unit(filename)
 
-                source_unit.add_contract_name(contract_name)
+                source_unit.contracts_names.add(contract_name)
                 compilation_unit.filename_to_contracts[filename].add(contract_name)
                 source_unit.abis[contract_name] = info["abi"]
 
@@ -325,6 +305,26 @@ def parse_standard_json_output(
                 source_unit.srcmaps_runtime[contract_name] = info["evm"]["deployedBytecode"][
                     "sourceMap"
                 ].split(";")
+
+    if "sources" in targets_json:
+        for path, info in targets_json["sources"].items():
+            if skip_filename:
+                path = convert_filename(
+                    path,
+                    relative_to_short,
+                    compilation_unit.crytic_compile,
+                    working_dir=solc_working_dir,
+                )
+            else:
+                path = convert_filename(
+                    path,
+                    relative_to_short,
+                    compilation_unit.crytic_compile,
+                    working_dir=solc_working_dir,
+                )
+            source_unit = compilation_unit.create_source_unit(path)
+
+            source_unit.ast = info.get("ast")
 
 
 # Inherits is_dependency/is_supported from Solc

--- a/crytic_compile/platform/standard.py
+++ b/crytic_compile/platform/standard.py
@@ -285,24 +285,12 @@ def _load_from_compile_legacy1(crytic_compile: "CryticCompile", loaded_json: Dic
         version=loaded_json["compiler"]["version"],
         optimized=loaded_json["compiler"]["optimized"],
     )
-
-    if "filenames" in loaded_json:
-        compilation_unit.filenames = [
-            _convert_dict_to_filename(filename) for filename in loaded_json["filenames"]
-        ]
-
-    for path, ast in loaded_json["asts"].items():
-        # The following might create lookup issue?
-        filename = crytic_compile.filename_lookup(path)
-        source_unit = compilation_unit.create_source_unit(filename)
-        source_unit.ast = ast
-
     for contract_name, contract in loaded_json["contracts"].items():
         filename = _convert_dict_to_filename(contract["filenames"])
         compilation_unit.filename_to_contracts[filename].add(contract_name)
         source_unit = compilation_unit.create_source_unit(filename)
 
-        source_unit.add_contract_name(contract_name)
+        source_unit.contracts_names.add(contract_name)
         source_unit.abis[contract_name] = contract["abi"]
         source_unit.bytecodes_init[contract_name] = contract["bin"]
         source_unit.bytecodes_runtime[contract_name] = contract["bin-runtime"]
@@ -320,6 +308,23 @@ def _load_from_compile_legacy1(crytic_compile: "CryticCompile", loaded_json: Dic
             compilation_unit.crytic_compile.dependencies.add(filename.short)
             compilation_unit.crytic_compile.dependencies.add(filename.used)
 
+    if "filenames" in loaded_json:
+        compilation_unit.filenames = {
+            _convert_dict_to_filename(filename) for filename in loaded_json["filenames"]
+        }
+    else:
+        # For legay code, we recover the filenames from the contracts list
+        # This is not perfect, as a filename might not be associated to any contract
+        for contract_name, contract in loaded_json["contracts"].items():
+            filename = _convert_dict_to_filename(contract["filenames"])
+            compilation_unit.filenames.add(filename)
+
+    for path, ast in loaded_json["asts"].items():
+        # The following might create lookup issue?
+        filename = crytic_compile.filename_lookup(path)
+        source_unit = compilation_unit.create_source_unit(filename)
+        source_unit.ast = ast
+
 
 def _load_from_compile_legacy2(crytic_compile: "CryticCompile", loaded_json: Dict) -> None:
     """Load from old (old) export
@@ -336,19 +341,6 @@ def _load_from_compile_legacy2(crytic_compile: "CryticCompile", loaded_json: Dic
             version=compilation_unit_json["compiler"]["version"],
             optimized=compilation_unit_json["compiler"]["optimized"],
         )
-
-        if "filenames" in compilation_unit_json:
-            compilation_unit.filenames = [
-                _convert_dict_to_filename(filename)
-                for filename in compilation_unit_json["filenames"]
-            ]
-
-        for path, ast in loaded_json["asts"].items():
-            # The following might create lookup issue?
-            filename = crytic_compile.filename_lookup(path)
-            source_unit = compilation_unit.create_source_unit(filename)
-            source_unit.ast = ast
-
         for contract_name, contract in compilation_unit_json["contracts"].items():
 
             filename = Filename(
@@ -360,7 +352,7 @@ def _load_from_compile_legacy2(crytic_compile: "CryticCompile", loaded_json: Dic
             compilation_unit.filename_to_contracts[filename].add(contract_name)
 
             source_unit = compilation_unit.create_source_unit(filename)
-            source_unit.add_contract_name(contract_name)
+            source_unit.contracts_names.add(contract_name)
             source_unit.abis[contract_name] = contract["abi"]
             source_unit.bytecodes_init[contract_name] = contract["bin"]
             source_unit.bytecodes_runtime[contract_name] = contract["bin-runtime"]
@@ -378,6 +370,24 @@ def _load_from_compile_legacy2(crytic_compile: "CryticCompile", loaded_json: Dic
                 crytic_compile.dependencies.add(filename.short)
                 crytic_compile.dependencies.add(filename.used)
 
+        if "filenames" in compilation_unit_json:
+            compilation_unit.filenames = {
+                _convert_dict_to_filename(filename)
+                for filename in compilation_unit_json["filenames"]
+            }
+        else:
+            # For legacy code, we recover the filenames from the contracts list
+            # This is not perfect, as a filename might not be associated to any contract
+            for contract_name, contract in compilation_unit_json["contracts"].items():
+                filename = _convert_dict_to_filename(contract["filenames"])
+                compilation_unit.filenames.add(filename)
+
+        for path, ast in loaded_json["asts"].items():
+            # The following might create lookup issue?
+            filename = crytic_compile.filename_lookup(path)
+            source_unit = compilation_unit.create_source_unit(filename)
+            source_unit.ast = ast
+
 
 def _load_from_compile_0_0_1(crytic_compile: "CryticCompile", loaded_json: Dict) -> None:
     for key, compilation_unit_json in loaded_json["compilation_units"].items():
@@ -387,17 +397,6 @@ def _load_from_compile_0_0_1(crytic_compile: "CryticCompile", loaded_json: Dict)
             version=compilation_unit_json["compiler"]["version"],
             optimized=compilation_unit_json["compiler"]["optimized"],
         )
-
-        compilation_unit.filenames = [
-            _convert_dict_to_filename(filename) for filename in compilation_unit_json["filenames"]
-        ]
-
-        for path, ast in compilation_unit_json["asts"].items():
-            # The following might create lookup issue?
-            filename = crytic_compile.filename_lookup(path)
-            source_unit = compilation_unit.create_source_unit(filename)
-            source_unit.ast = ast
-
         for contracts_data in compilation_unit_json["contracts"].values():
             for contract_name, contract in contracts_data.items():
 
@@ -409,7 +408,7 @@ def _load_from_compile_0_0_1(crytic_compile: "CryticCompile", loaded_json: Dict)
                 )
                 compilation_unit.filename_to_contracts[filename].add(contract_name)
                 source_unit = compilation_unit.create_source_unit(filename)
-                source_unit.add_contract_name(contract_name)
+                source_unit.contracts_names.add(contract_name)
                 source_unit.abis[contract_name] = contract["abi"]
                 source_unit.bytecodes_init[contract_name] = contract["bin"]
                 source_unit.bytecodes_runtime[contract_name] = contract["bin-runtime"]
@@ -427,6 +426,16 @@ def _load_from_compile_0_0_1(crytic_compile: "CryticCompile", loaded_json: Dict)
                     crytic_compile.dependencies.add(filename.short)
                     crytic_compile.dependencies.add(filename.used)
 
+        compilation_unit.filenames = {
+            _convert_dict_to_filename(filename) for filename in compilation_unit_json["filenames"]
+        }
+
+        for path, ast in compilation_unit_json["asts"].items():
+            # The following might create lookup issue?
+            filename = crytic_compile.filename_lookup(path)
+            source_unit = compilation_unit.create_source_unit(filename)
+            source_unit.ast = ast
+
 
 def _load_from_compile_current(crytic_compile: "CryticCompile", loaded_json: Dict) -> None:
     for key, compilation_unit_json in loaded_json["compilation_units"].items():
@@ -437,9 +446,9 @@ def _load_from_compile_current(crytic_compile: "CryticCompile", loaded_json: Dic
             optimized=compilation_unit_json["compiler"]["optimized"],
         )
 
-        compilation_unit.filenames = [
+        compilation_unit.filenames = {
             _convert_dict_to_filename(filename) for filename in compilation_unit_json["filenames"]
-        ]
+        }
 
         for filename_str, source_unit_data in compilation_unit_json["source_units"].items():
             filename = compilation_unit.filename_lookup(filename_str)
@@ -449,7 +458,7 @@ def _load_from_compile_current(crytic_compile: "CryticCompile", loaded_json: Dic
                 compilation_unit.filename_to_contracts[filename].add(contract_name)
 
                 source_unit = compilation_unit.create_source_unit(filename)
-                source_unit.add_contract_name(contract_name)
+                source_unit.contracts_names.add(contract_name)
                 source_unit.abis[contract_name] = contract["abi"]
                 source_unit.bytecodes_init[contract_name] = contract["bin"]
                 source_unit.bytecodes_runtime[contract_name] = contract["bin-runtime"]

--- a/crytic_compile/platform/truffle.py
+++ b/crytic_compile/platform/truffle.py
@@ -251,7 +251,7 @@ class Truffle(AbstractPlatform):
                 contract_name = target_loaded["contractName"]
                 source_unit.natspec[contract_name] = natspec
                 compilation_unit.filename_to_contracts[filename].add(contract_name)
-                source_unit.add_contract_name(contract_name)
+                source_unit.contracts_names.add(contract_name)
                 source_unit.abis[contract_name] = target_loaded["abi"]
                 source_unit.bytecodes_init[contract_name] = target_loaded["bytecode"].replace(
                     "0x", ""

--- a/crytic_compile/platform/vyper.py
+++ b/crytic_compile/platform/vyper.py
@@ -65,7 +65,7 @@ class Vyper(AbstractPlatform):
 
         source_unit = compilation_unit.create_source_unit(filename)
 
-        source_unit.add_contract_name(contract_name)
+        source_unit.contracts_names.add(contract_name)
         compilation_unit.filename_to_contracts[filename].add(contract_name)
         source_unit.abis[contract_name] = info["abi"]
         source_unit.bytecodes_init[contract_name] = info["bytecode"].replace("0x", "")

--- a/crytic_compile/platform/waffle.py
+++ b/crytic_compile/platform/waffle.py
@@ -181,12 +181,6 @@ class Waffle(AbstractPlatform):
 
         compilation_unit = CompilationUnit(crytic_compile, str(target))
 
-        if "sources" in target_all:
-            compilation_unit.filenames = [
-                convert_filename(path, _relative_to_short, crytic_compile, working_dir=target)
-                for path in target_all["sources"]
-            ]
-
         for contract in target_all["contracts"]:
             target_loaded = target_all["contracts"][contract]
             contract = contract.split(":")
@@ -198,8 +192,9 @@ class Waffle(AbstractPlatform):
             source_unit = compilation_unit.create_source_unit(filename)
 
             source_unit.ast = target_all["sources"][contract[0]]["AST"]
+            compilation_unit.filenames.add(filename)
             compilation_unit.filename_to_contracts[filename].add(contract_name)
-            source_unit.add_contract_name(contract_name)
+            source_unit.contracts_names.add(contract_name)
             source_unit.abis[contract_name] = target_loaded["abi"]
 
             userdoc = target_loaded.get("userdoc", {})

--- a/crytic_compile/source_unit.py
+++ b/crytic_compile/source_unit.py
@@ -4,7 +4,7 @@ Each source unit represents one file so may be associated with
 One or more source units are associated with each compilation unit
 """
 import re
-from typing import Dict, List, Optional, Union, Tuple, TYPE_CHECKING
+from typing import Dict, List, Optional, Union, Tuple, Set, TYPE_CHECKING
 import cbor2
 
 from Crypto.Hash import keccak
@@ -60,7 +60,7 @@ def get_library_candidate(filename: Filename, contract_name: str) -> List[str]:
     return ret
 
 
-# pylint: disable=too-many-instance-attributes,too-many-public-methods
+# pylint: disable=too-many-instance-attributes
 class SourceUnit:
     """SourceUnit class"""
 
@@ -87,10 +87,10 @@ class SourceUnit:
         self._libraries: Dict[str, List[Tuple[str, str]]] = {}
 
         # set containing all the contract names
-        self._contracts_name: List[str] = []
+        self._contracts_name: Set[str] = set()
 
         # set containing all the contract name without the libraries
-        self._contracts_name_without_libraries: Optional[List[str]] = None
+        self._contracts_name_without_libraries: Optional[Set[str]] = None
 
     # region ABI
     ###################################################################################
@@ -411,46 +411,37 @@ class SourceUnit:
     ###################################################################################
 
     @property
-    def contracts_names(self) -> List[str]:
+    def contracts_names(self) -> Set[str]:
         """Return the contracts names
 
         Returns:
-            List[str]: List of the contracts names
+            Set[str]: List of the contracts names
         """
         return self._contracts_name
 
     @contracts_names.setter
-    def contracts_names(self, names: List[str]) -> None:
+    def contracts_names(self, names: Set[str]) -> None:
         """Set the contract names
 
         Args:
-            names (List[str]): New contracts names
+            names (Set[str]): New contracts names
         """
         self._contracts_name = names
 
-    def add_contract_name(self, name: str) -> None:
-        """Add name to contracts_names, if not already present
-
-        Args:
-            name (str): Name to add to the list
-        """
-        if name not in self.contracts_names:
-            self.contracts_names.append(name)
-
     @property
-    def contracts_names_without_libraries(self) -> List[str]:
+    def contracts_names_without_libraries(self) -> Set[str]:
         """Return the contracts names without the librairies
 
         Returns:
-            List[str]: List of contracts
+            Set[str]: List of contracts
         """
         if self._contracts_name_without_libraries is None:
             libraries: List[str] = []
             for contract_name in self._contracts_name:
                 libraries += self.libraries_names(contract_name)
-            self._contracts_name_without_libraries = [
+            self._contracts_name_without_libraries = {
                 l for l in self._contracts_name if l not in set(libraries)
-            ]
+            }
         return self._contracts_name_without_libraries
 
     # endregion


### PR DESCRIPTION
Reverts crytic/crytic-compile#436