### PR TITLE
Add CompilationUnit.implementation_address when the CU is a proxy contract

### DIFF
--- a/crytic_compile/compilation_unit.py
+++ b/crytic_compile/compilation_unit.py
@@ -46,6 +46,10 @@ class CompilationUnit:
             compiler="N/A", version="N/A", optimized=False
         )
 
+        # if the compilation unit comes from etherscan-like service and is a proxy,
+        # store the implementation address
+        self._implementation_address: Optional[str] = None
+
         self._crytic_compile: "CryticCompile" = crytic_compile
 
         if unique_id == ".":
@@ -129,6 +133,24 @@ class CompilationUnit:
             if filename not in self.filenames:
                 self.filenames.append(filename)
         return self._source_units[filename]
+
+    @property
+    def implementation_address(self) -> Optional[str]:
+        """Return the implementation address if the compilation unit is a proxy
+
+        Returns:
+            Optional[str]: Implementation address
+        """
+        return self._implementation_address
+
+    @implementation_address.setter
+    def implementation_address(self, implementation: str) -> None:
+        """Set the implementation address
+
+        Args:
+            implementation (str): Implementation address
+        """
+        self._implementation_address = implementation
 
     # endregion
     ###################################################################################

--- a/crytic_compile/platform/etherscan.py
+++ b/crytic_compile/platform/etherscan.py
@@ -382,6 +382,14 @@ class Etherscan(AbstractPlatform):
             optimize_runs=optimize_runs,
         )
         compilation_unit.compiler_version.look_for_installed_version()
+
+        if "Proxy" in result and result["Proxy"] == "1":
+            assert "Implementation" in result
+            implementation = result["Implementation"]
+            if prefix is not None:
+                implementation = f"{prefix}:{implementation}"
+            compilation_unit.implementation_address = implementation
+
         solc_standard_json.standalone_compile(
             filenames,
             compilation_unit,

--- a/crytic_compile/platform/etherscan.py
+++ b/crytic_compile/platform/etherscan.py
@@ -386,8 +386,8 @@ class Etherscan(AbstractPlatform):
         if "Proxy" in result and result["Proxy"] == "1":
             assert "Implementation" in result
             implementation = str(result["Implementation"])
-            if prefix is not None:
-                implementation = f"{prefix}:{implementation}"
+            if target.startswith(tuple(SUPPORTED_NETWORK)):
+                implementation = f"{target[:target.find(':')]}:{implementation}"
             compilation_unit.implementation_address = implementation
 
         solc_standard_json.standalone_compile(

--- a/crytic_compile/platform/etherscan.py
+++ b/crytic_compile/platform/etherscan.py
@@ -385,7 +385,7 @@ class Etherscan(AbstractPlatform):
 
         if "Proxy" in result and result["Proxy"] == "1":
             assert "Implementation" in result
-            implementation = result["Implementation"]
+            implementation = str(result["Implementation"])
             if prefix is not None:
                 implementation = f"{prefix}:{implementation}"
             compilation_unit.implementation_address = implementation


### PR DESCRIPTION
This is a small step towards https://github.com/crytic/crytic-compile/issues/132. Instead of following the proxy within crytic-compile, this PR allows applications built on top of crytic-compile or slither to do that themselves.