### PR TITLE
Foundry `--skip test script` by default 

### DIFF
--- a/crytic_compile/cryticparser/cryticparser.py
+++ b/crytic_compile/cryticparser/cryticparser.py
@@ -496,3 +496,11 @@ def _init_foundry(parser: ArgumentParser) -> None:
         dest="foundry_out_directory",
         default=DEFAULTS_FLAG_IN_CONFIG["foundry_out_directory"],
     )
+
+    group_foundry.add_argument(
+        "--foundry-dont-skip",
+        help='Do not add "--skip test script" flags',
+        action="store_true",
+        dest="foundry_dont_skip",
+        default=DEFAULTS_FLAG_IN_CONFIG["foundry_dont_skip"],
+    )

--- a/crytic_compile/cryticparser/defaults.py
+++ b/crytic_compile/cryticparser/defaults.py
@@ -45,6 +45,7 @@ DEFAULTS_FLAG_IN_CONFIG = {
     "hardhat_artifacts_directory": None,
     "foundry_ignore_compile": False,
     "foundry_out_directory": "out",
+    "foundry_dont_skip": False,
     "export_dir": "crytic-export",
     "compile_libraries": None,
 }

--- a/crytic_compile/platform/foundry.py
+++ b/crytic_compile/platform/foundry.py
@@ -49,14 +49,22 @@ class Foundry(AbstractPlatform):
             )
 
         if not ignore_compile:
-            run(
-                [
-                    "forge",
-                    "build",
-                    "--build-info",
-                ],
-                cwd=self._target,
-            )
+            commands_to_run = [
+                "forge",
+                "build",
+                "--build-info",
+            ]
+
+            dont_skip = kwargs.get("foundry_dont_skip", False)
+            if not dont_skip:
+                # Adding flags to skip test/ and script/ directory
+                commands_to_run += [
+                    "--skip",
+                    "test",
+                    "script",
+                ]
+
+            run(commands_to_run, cwd=self._target)
 
         build_directory = Path(
             self._target,

--- a/crytic_compile/platform/foundry.py
+++ b/crytic_compile/platform/foundry.py
@@ -60,8 +60,9 @@ class Foundry(AbstractPlatform):
                 # Adding flags to skip test/ and script/ directory
                 commands_to_run += [
                     "--skip",
-                    "test",
-                    "script",
+                    "*/test/**",
+                    "*/script/**",
+                    "--force",
                 ]
 
             run(commands_to_run, cwd=self._target)


### PR DESCRIPTION
Fixes #435 

I tried to see if I could fix this quickly, and it seems to work.

Let me know if you would like to fix the naming or how the flag should behave, I can work on that