### PR TITLE
Add support for Hardhat CommonJS config, clean up platform ordering

### DIFF
--- a/crytic_compile/crytic_compile.py
+++ b/crytic_compile/crytic_compile.py
@@ -36,14 +36,14 @@ logging.basicConfig()
 
 
 def get_platforms() -> List[Type[AbstractPlatform]]:
-    """Return the available platforms classes
+    """Return the available platforms classes in order of preference
 
     Returns:
         List[Type[AbstractPlatform]]: Available platforms
     """
     platforms = [getattr(all_platforms, name) for name in dir(all_platforms)]
     platforms = [d for d in platforms if inspect.isclass(d) and issubclass(d, AbstractPlatform)]
-    return sorted(platforms, key=lambda platform: platform.TYPE)
+    return sorted(platforms, key=lambda platform: (platform.TYPE.priority(), platform.TYPE))
 
 
 def is_supported(target: str) -> bool:

--- a/crytic_compile/platform/hardhat.py
+++ b/crytic_compile/platform/hardhat.py
@@ -212,10 +212,6 @@ class Hardhat(AbstractPlatform):
         if hardhat_ignore:
             return False
 
-        # If there is both foundry and hardhat, foundry takes priority
-        if os.path.isfile(os.path.join(target, "foundry.toml")):
-            return False
-
         return (
             os.path.isfile(os.path.join(target, "hardhat.config.js"))
             or os.path.isfile(os.path.join(target, "hardhat.config.ts"))

--- a/crytic_compile/platform/hardhat.py
+++ b/crytic_compile/platform/hardhat.py
@@ -216,8 +216,10 @@ class Hardhat(AbstractPlatform):
         if os.path.isfile(os.path.join(target, "foundry.toml")):
             return False
 
-        return os.path.isfile(os.path.join(target, "hardhat.config.js")) | os.path.isfile(
-            os.path.join(target, "hardhat.config.ts")
+        return (
+            os.path.isfile(os.path.join(target, "hardhat.config.js"))
+            or os.path.isfile(os.path.join(target, "hardhat.config.ts"))
+            or os.path.isfile(os.path.join(target, "hardhat.config.cjs"))
         )
 
     def is_dependency(self, path: str) -> bool:

--- a/crytic_compile/platform/truffle.py
+++ b/crytic_compile/platform/truffle.py
@@ -305,12 +305,6 @@ class Truffle(AbstractPlatform):
         if truffle_ignore:
             return False
 
-        # Avoid conflicts with hardhat
-        if os.path.isfile(os.path.join(target, "hardhat.config.js")) | os.path.isfile(
-            os.path.join(target, "hardhat.config.ts")
-        ):
-            return False
-
         return os.path.isfile(os.path.join(target, "truffle.js")) or os.path.isfile(
             os.path.join(target, "truffle-config.js")
         )

--- a/crytic_compile/platform/types.py
+++ b/crytic_compile/platform/types.py
@@ -66,3 +66,24 @@ class Type(IntEnum):
         if self == Type.FOUNDRY:
             return "Foundry"
         raise ValueError
+
+    def priority(self) -> int:
+        """Return the priority for a certain platform.
+
+        A lower priority means the platform is more preferable. This is used to
+        consistently select a platform when two or more are available.
+
+        Returns:
+            int: priority number
+        """
+
+        if self == Type.FOUNDRY:
+            return 100
+
+        if self == Type.HARDHAT:
+            return 200
+
+        if self in [Type.TRUFFLE, Type.WAFFLE]:
+            return 300
+
+        return 1000

--- a/crytic_compile/platform/waffle.py
+++ b/crytic_compile/platform/waffle.py
@@ -245,12 +245,6 @@ class Waffle(AbstractPlatform):
         if waffle_ignore:
             return False
 
-        # Avoid conflicts with hardhat
-        if os.path.isfile(os.path.join(target, "hardhat.config.js")) | os.path.isfile(
-            os.path.join(target, "hardhat.config.ts")
-        ):
-            return False
-
         if os.path.isfile(os.path.join(target, "waffle.json")) or os.path.isfile(
             os.path.join(target, ".waffle.json")
         ):


### PR DESCRIPTION
This PR adds support for the new Hardhat CJS config file (`hardhat.config.cjs`). It also cleans up the current platform priority checks that were implemented by special cases in `is_supported`, by replacing them with a prioritized order of platforms.

Fixes #467