### PR TITLE
Allow 20 byte address for --compile-libraries and raise error if argument is invalid

### DIFF
--- a/crytic_compile/crytic_compile.py
+++ b/crytic_compile/crytic_compile.py
@@ -63,8 +63,8 @@ def _extract_libraries(libraries_str: Optional[str]) -> Optional[Dict[str, int]]
 
     if not libraries_str:
         return None
-
-    pattern = r"\((?P<name>\w+),\s*(?P<value1>0x[0-9a-fA-F]{2})\),?"
+    # Extract tuple like (libname1, 0x00)
+    pattern = r"\((?P<name>\w+),\s*(?P<value1>0x[0-9a-fA-F]{2,40})\),?"
     matches = re.findall(pattern, libraries_str)
 
     if not matches:

--- a/crytic_compile/crytic_compile.py
+++ b/crytic_compile/crytic_compile.py
@@ -68,8 +68,9 @@ def _extract_libraries(libraries_str: Optional[str]) -> Optional[Dict[str, int]]
     matches = re.findall(pattern, libraries_str)
 
     if not matches:
-        logging.info(f"Libraries {libraries_str} could not be parsed")
-        return None
+        raise ValueError(
+            f"Invalid library linking directive\nGot:\n{libraries_str}\nExpected format:\n(libname1, 0x00),(libname2, 0x02)"
+        )
 
     ret: Dict[str, int] = {}
     for key, value in matches:

--- a/tests/library_linking.sol
+++ b/tests/library_linking.sol
@@ -1,0 +1,16 @@
+library NeedsLinkingA {
+    function testA() external pure returns (uint) {
+        return type(uint).max;
+    }
+}
+library NeedsLinkingB {
+    function testB() external pure returns (uint) {
+        return type(uint).min;
+    }
+}
+contract TestLibraryLinking {
+    function test() external {
+        NeedsLinkingA.testA();
+        NeedsLinkingB.testB();
+    }
+}

--- a/tests/test_library_linking.py
+++ b/tests/test_library_linking.py
@@ -11,7 +11,7 @@ TEST_DIR = Path(__file__).resolve().parent
 LIBRARY_PLACEHOLDER_REGEX = r"__.{36}__"
 
 
-def test_library_linking():
+def test_library_linking() -> None:
     cc = CryticCompile(
         Path(TEST_DIR / "library_linking.sol").as_posix(),
         compile_libraries="(NeedsLinkingA, 0xdead),(NeedsLinkingB, 0x000000000000000000000000000000000000beef)",
@@ -45,7 +45,7 @@ def test_library_linking():
             )
 
 
-def test_library_linking_validation():
+def test_library_linking_validation() -> None:
     with pytest.raises(ValueError):
         cc = CryticCompile(
             Path(TEST_DIR / "library_linking.sol").as_posix(),

--- a/tests/test_library_linking.py
+++ b/tests/test_library_linking.py
@@ -1,0 +1,53 @@
+"""
+Test library linking
+"""
+import re
+import pytest
+from pathlib import Path
+from crytic_compile.crytic_compile import CryticCompile
+
+TEST_DIR = Path(__file__).resolve().parent
+
+LIBRARY_PLACEHOLDER_REGEX = r"__.{36}__"
+
+
+def test_library_linking():
+    cc = CryticCompile(
+        Path(TEST_DIR / "library_linking.sol").as_posix(),
+        compile_libraries="(NeedsLinkingA, 0xdead),(NeedsLinkingB, 0x000000000000000000000000000000000000beef)",
+    )
+    for compilation_unit in cc.compilation_units.values():
+        for source_unit in compilation_unit.source_units.values():
+            assert (
+                len(re.findall(r"__.{36}__", source_unit.bytecode_init("TestLibraryLinking"))) == 2
+            )
+            assert (
+                len(re.findall(r"__.{36}__", source_unit.bytecode_runtime("TestLibraryLinking")))
+                == 2
+            )
+            # Test that the placeholder is not present in the bytecode when the libraries are provided
+            libraries = compilation_unit.crytic_compile.libraries
+            assert (
+                len(
+                    re.findall(
+                        r"__.{36}__", source_unit.bytecode_init("TestLibraryLinking", libraries)
+                    )
+                )
+                == 0
+            )
+            assert (
+                len(
+                    re.findall(
+                        r"__.{36}__", source_unit.bytecode_runtime("TestLibraryLinking", libraries)
+                    )
+                )
+                == 0
+            )
+
+
+def test_library_linking_validation():
+    with pytest.raises(ValueError):
+        cc = CryticCompile(
+            Path(TEST_DIR / "library_linking.sol").as_posix(),
+            compile_libraries="(NeedsLinkingA, 0x)",
+        )

--- a/tests/test_library_linking.py
+++ b/tests/test_library_linking.py
@@ -2,8 +2,8 @@
 Test library linking
 """
 import re
-import pytest
 from pathlib import Path
+import pytest
 from crytic_compile.crytic_compile import CryticCompile
 
 TEST_DIR = Path(__file__).resolve().parent
@@ -12,6 +12,7 @@ LIBRARY_PLACEHOLDER_REGEX = r"__.{36}__"
 
 
 def test_library_linking() -> None:
+    """Test that the placeholder is not present in the bytecode when the libraries are provided"""
     cc = CryticCompile(
         Path(TEST_DIR / "library_linking.sol").as_posix(),
         compile_libraries="(NeedsLinkingA, 0xdead),(NeedsLinkingB, 0x000000000000000000000000000000000000beef)",
@@ -25,7 +26,6 @@ def test_library_linking() -> None:
                 len(re.findall(r"__.{36}__", source_unit.bytecode_runtime("TestLibraryLinking")))
                 == 2
             )
-            # Test that the placeholder is not present in the bytecode when the libraries are provided
             libraries = compilation_unit.crytic_compile.libraries
             assert (
                 len(
@@ -46,8 +46,9 @@ def test_library_linking() -> None:
 
 
 def test_library_linking_validation() -> None:
+    """Test that invalid compile libraries argument raises an error"""
     with pytest.raises(ValueError):
-        cc = CryticCompile(
+        CryticCompile(
             Path(TEST_DIR / "library_linking.sol").as_posix(),
             compile_libraries="(NeedsLinkingA, 0x)",
         )


### PR DESCRIPTION
Allow 20 byte address for `--compile-libraries` and raise error if argument is invalid

Fixes https://github.com/crytic/crytic-compile/issues/476

xref https://github.com/crytic/echidna/issues/651