### PR TITLE
Adding EVM chain support

### DIFF
--- a/crytic_compile/platform/etherscan.py
+++ b/crytic_compile/platform/etherscan.py
@@ -50,6 +50,9 @@ SUPPORTED_NETWORK = {
     "testnet.avax:": ("-testnet.snowtrace.io", "testnet.snowtrace.io"),
     "ftm:": (".ftmscan.com", "ftmscan.com"),
     "goerli.base:": ("-goerli.basescan.org", "goerli.basescan.org"),
+    "base:": (".basescan.org", "basescan.org"),
+    "gno:": (".gnosisscan.io", "gnosisscan.io"),
+    "polyzk:": ("-zkevm.polygonscan.com", "zkevm.polygonscan.com"),
 }
 
 
@@ -237,6 +240,9 @@ class Etherscan(AbstractPlatform):
         ftmscan_api_key = kwargs.get("ftmscan_api_key", None)
         bscan_api_key = kwargs.get("bscan_api_key", None)
         optim_api_key = kwargs.get("optim_api_key", None)
+        base_api_key = kwargs.get("base_api_key", None)
+        gno_api_key = kwargs.get("gno_api_key", None)
+        polyzk_api_key = kwargs.get("polyzk_api_key", None)
 
         export_dir = kwargs.get("export_dir", "crytic-export")
         export_dir = os.path.join(
@@ -267,6 +273,15 @@ class Etherscan(AbstractPlatform):
         if optim_api_key and "optim" in etherscan_url:
             etherscan_url += f"&apikey={optim_api_key}"
             etherscan_bytecode_url += f"&apikey={optim_api_key}"
+        if base_api_key and "base" in etherscan_url:
+            etherscan_url += f"&apikey={base_api_key}"
+            etherscan_bytecode_url += f"&apikey={base_api_key}"
+        if gno_api_key and "gno" in etherscan_url:
+            etherscan_url += f"&apikey={gno_api_key}"
+            etherscan_bytecode_url += f"&apikey={gno_api_key}"
+        if polyzk_api_key and "zkevm" in etherscan_url:
+            etherscan_url += f"&apikey={polyzk_api_key}"
+            etherscan_bytecode_url += f"&apikey={polyzk_api_key}"
 
         source_code: str = ""
         result: Dict[str, Union[bool, str, int]] = {}

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ setup(
     description="Util to facilitate smart contracts compilation.",
     url="https://github.com/crytic/crytic-compile",
     author="Trail of Bits",
-    version="0.3.0",
+    version="0.3.1",
     packages=find_packages(),
     python_requires=">=3.8",
     install_requires=["pycryptodome>=3.4.6", "cbor2", "solc-select>=v1.0.2"],


### PR DESCRIPTION
Adding support for the following EVM chains:

1.  Base (https://basescan.org/)
2. Gnosis (https://gnosisscan.io/)
3. PolygonZkEVM (https://zkevm.polygonscan.com/)