### PR TITLE
feat: compile vyper 0.3.7 via standard json input

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
       fail-fast: false
       matrix:
         os: ["ubuntu-latest", "windows-2022"]
-        type: ["brownie", "buidler", "dapp", "embark", "hardhat", "solc", "truffle", "waffle", "foundry", "standard"]
+        type: ["brownie", "buidler", "dapp", "embark", "hardhat", "solc", "truffle", "waffle", "foundry", "standard", "vyper"]
         exclude:
           # Currently broken, tries to pull git:// which is blocked by GH
           - type: embark

--- a/crytic_compile/crytic_compile.py
+++ b/crytic_compile/crytic_compile.py
@@ -623,7 +623,7 @@ def compile_all(target: str, **kwargs: str) -> List[CryticCompile]:
         **kwargs: optional arguments. Used: "solc_standard_json"
 
     Raises:
-        ValueError: If the target could not be compiled
+        NotImplementedError: If the target could not be compiled
 
     Returns:
         List[CryticCompile]: Returns a list of CryticCompile instances for all compilations which occurred.

--- a/crytic_compile/crytic_compile.py
+++ b/crytic_compile/crytic_compile.py
@@ -15,7 +15,9 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Dict, List, Optional, Set, Tuple, Type, Union
 
 from crytic_compile.compilation_unit import CompilationUnit
-from crytic_compile.platform import all_platforms, solc_standard_json
+from crytic_compile.platform import all_platforms
+from crytic_compile.platform.solc_standard_json import SolcStandardJson
+from crytic_compile.platform.vyper import VyperStandardJson
 from crytic_compile.platform.abstract_platform import AbstractPlatform
 from crytic_compile.platform.all_export import PLATFORMS_EXPORT
 from crytic_compile.platform.solc import Solc
@@ -628,11 +630,7 @@ def compile_all(target: str, **kwargs: str) -> List[CryticCompile]:
     """
     use_solc_standard_json = kwargs.get("solc_standard_json", False)
 
-    # Attempt to perform glob expansion of target/filename
-    globbed_targets = glob.glob(target, recursive=True)
-
     # Check if the target refers to a valid target already.
-    # If it does not, we assume it's a glob pattern.
     compilations: List[CryticCompile] = []
     if os.path.isfile(target) or is_supported(target):
         if target.endswith(".zip"):
@@ -644,28 +642,33 @@ def compile_all(target: str, **kwargs: str) -> List[CryticCompile]:
                     compilations = load_from_zip(tmp.name)
         else:
             compilations.append(CryticCompile(target, **kwargs))
-    elif os.path.isdir(target) or len(globbed_targets) > 0:
-        # We create a new glob to find solidity files at this path (in case this is a directory)
-        filenames = glob.glob(os.path.join(target, "*.sol"))
-        if not filenames:
-            filenames = glob.glob(os.path.join(target, "*.vy"))
-            if not filenames:
-                filenames = globbed_targets
-
+    elif os.path.isdir(target):
+        solidity_filenames = glob.glob(os.path.join(target, "*.sol"))
+        vyper_filenames = glob.glob(os.path.join(target, "*.vy"))
         # Determine if we're using --standard-solc option to
         # aggregate many files into a single compilation.
         if use_solc_standard_json:
             # If we're using standard solc, then we generated our
             # input to create a single compilation with all files
-            standard_json = solc_standard_json.SolcStandardJson()
-            for filename in filenames:
-                standard_json.add_source_file(filename)
-            compilations.append(CryticCompile(standard_json, **kwargs))
+            solc_standard_json = SolcStandardJson()
+            solc_standard_json.add_source_files(solidity_filenames)
+            compilations.append(CryticCompile(solc_standard_json, **kwargs))
         else:
             # We compile each file and add it to our compilations.
-            for filename in filenames:
+            for filename in solidity_filenames:
                 compilations.append(CryticCompile(filename, **kwargs))
+
+        if vyper_filenames:
+            vyper_standard_json = VyperStandardJson()
+            vyper_standard_json.add_source_files(vyper_filenames)
+            compilations.append(CryticCompile(vyper_standard_json, **kwargs))
     else:
-        raise ValueError(f"{str(target)} is not a file or directory.")
+        raise NotImplementedError()
+        # TODO split glob into language
+        # # Attempt to perform glob expansion of target/filename
+        # globbed_targets = glob.glob(target, recursive=True)
+        # print(globbed_targets)
+
+        # raise ValueError(f"{str(target)} is not a file or directory.")
 
     return compilations

--- a/crytic_compile/platform/all_platforms.py
+++ b/crytic_compile/platform/all_platforms.py
@@ -14,6 +14,6 @@ from .solc import Solc
 from .solc_standard_json import SolcStandardJson
 from .standard import Standard
 from .truffle import Truffle
-from .vyper import Vyper
+from .vyper import VyperStandardJson
 from .waffle import Waffle
 from .foundry import Foundry

--- a/crytic_compile/platform/solc_standard_json.py
+++ b/crytic_compile/platform/solc_standard_json.py
@@ -405,6 +405,15 @@ class SolcStandardJson(Solc):
         """
         add_source_file(self._json, file_path)
 
+    def add_source_files(self, files_path: List[str]) -> None:
+        """Append files
+
+        Args:
+            files_path (List[str]): files to append
+        """
+        for file_path in files_path:
+            add_source_file(self._json, file_path)
+
     def add_remapping(self, remapping: str) -> None:
         """Append our remappings
 

--- a/crytic_compile/platform/vyper.py
+++ b/crytic_compile/platform/vyper.py
@@ -35,7 +35,7 @@ class VyperStandardJson(AbstractPlatform):
     TYPE = Type.VYPER
 
     def __init__(self, target: Optional[Path] = None, **_kwargs: str):
-        super().__init__(target, **_kwargs)
+        super().__init__(str(target), **_kwargs)
         self.standard_json_input = {
             "language": "Vyper",
             "sources": {},
@@ -123,7 +123,7 @@ class VyperStandardJson(AbstractPlatform):
 
         for file_path in file_paths:
             with open(file_path, "r", encoding="utf8") as f:
-                self.standard_json_input["sources"][file_path] = {
+                self.standard_json_input["sources"][file_path] = {  # type: ignore
                     "content": f.read(),
                 }
 

--- a/crytic_compile/platform/vyper.py
+++ b/crytic_compile/platform/vyper.py
@@ -103,7 +103,7 @@ class VyperStandardJson(AbstractPlatform):
                 source_unit.srcmaps_init[contract_name] = []
                 source_unit.srcmaps_runtime[contract_name] = contract_metadata["evm"][
                     "deployedBytecode"
-                ]["sourceMap"]
+                ]["sourceMap"].split(";")
                 source_unit.bytecodes_runtime[contract_name] = contract_metadata["evm"][
                     "deployedBytecode"
                 ]["object"].replace("0x", "")

--- a/crytic_compile/platform/vyper.py
+++ b/crytic_compile/platform/vyper.py
@@ -4,8 +4,8 @@ Vyper platform
 import json
 import logging
 import os
-import subprocess
 import shutil
+import subprocess
 from pathlib import Path
 from typing import TYPE_CHECKING, Dict, List, Optional
 
@@ -15,7 +15,6 @@ from crytic_compile.platform.abstract_platform import AbstractPlatform
 from crytic_compile.platform.exceptions import InvalidCompilation
 from crytic_compile.platform.types import Type
 from crytic_compile.utils.naming import convert_filename
-from crytic_compile.utils.subprocess import run
 
 # Handle cycle
 from crytic_compile.utils.natspec import Natspec
@@ -112,8 +111,18 @@ class VyperStandardJson(AbstractPlatform):
             source_unit.ast = ast
 
     def add_source_files(self, file_paths: List[str]) -> None:
+        """
+        Append files
+
+        Args:
+            file_paths (List[str]): files to append
+
+        Returns:
+
+        """
+
         for file_path in file_paths:
-            with open(file_path, "r") as f:
+            with open(file_path, "r", encoding="utf8") as f:
                 self.standard_json_input["sources"][file_path] = {
                     "content": f.read(),
                 }
@@ -163,10 +172,7 @@ class VyperStandardJson(AbstractPlatform):
 
 
 def _run_vyper_standard_json(
-    standard_json_input: Dict,
-    vyper: str,
-    env: Optional[Dict] = None,
-    working_dir: Optional[str] = None,
+    standard_json_input: Dict, vyper: str, env: Optional[Dict] = None
 ) -> Dict:
     """Run vyper and write compilation output to a file
 
@@ -174,7 +180,6 @@ def _run_vyper_standard_json(
         standard_json_input (Dict): Dict containing the vyper standard json input
         vyper (str): vyper binary
         env (Optional[Dict], optional): Environment variables. Defaults to None.
-        working_dir (Optional[str], optional): Working directory. Defaults to None.
 
     Raises:
         InvalidCompilation: If vyper failed to run
@@ -194,7 +199,7 @@ def _run_vyper_standard_json(
     ) as process:
 
         stdout_b, stderr_b = process.communicate(json.dumps(standard_json_input).encode("utf-8"))
-        stdout, stderr = (
+        stdout, _stderr = (
             stdout_b.decode(),
             stderr_b.decode(errors="backslashreplace"),
         )  # convert bytestrings to unicode strings

--- a/crytic_compile/platform/vyper.py
+++ b/crytic_compile/platform/vyper.py
@@ -78,7 +78,7 @@ class VyperStandardJson(AbstractPlatform):
 
         compiler_version = compilation_artifacts["compiler"].split("-")[1]
         if compiler_version != "0.3.7":
-            logging.info("Vyper != 0.3.7 support is a best effort and might fail")
+            LOGGER.info("Vyper != 0.3.7 support is a best effort and might fail")
         compilation_unit.compiler_version = CompilerVersion(
             compiler="vyper", version=compiler_version, optimized=False
         )

--- a/crytic_compile/platform/vyper.py
+++ b/crytic_compile/platform/vyper.py
@@ -77,7 +77,8 @@ class VyperStandardJson(AbstractPlatform):
         compilation_unit = CompilationUnit(crytic_compile, str(target))
 
         compiler_version = compilation_artifacts["compiler"].split("-")[1]
-        assert compiler_version == "0.3.7"
+        if compiler_version != "0.3.7":
+            logging.info("Vyper != 0.3.7 support is a best effort and might fail")
         compilation_unit.compiler_version = CompilerVersion(
             compiler="vyper", version=compiler_version, optimized=False
         )

--- a/crytic_compile/platform/vyper.py
+++ b/crytic_compile/platform/vyper.py
@@ -33,28 +33,28 @@ class VyperStandardJson(AbstractPlatform):
     NAME = "vyper"
     PROJECT_URL = "https://github.com/vyperlang/vyper"
     TYPE = Type.VYPER
-    standard_json_input: Dict = {
-        "language": "Vyper",
-        "sources": {},
-        "settings": {
-            "outputSelection": {
-                "*": {
-                    "*": [
-                        "abi",
-                        "devdoc",
-                        "userdoc",
-                        "evm.bytecode",
-                        "evm.deployedBytecode",
-                        "evm.deployedBytecode.sourceMap",
-                    ],
-                    "": ["ast"],
-                }
-            }
-        },
-    }
 
     def __init__(self, target: Optional[Path] = None, **_kwargs: str):
         super().__init__(target, **_kwargs)
+        self.standard_json_input = {
+            "language": "Vyper",
+            "sources": {},
+            "settings": {
+                "outputSelection": {
+                    "*": {
+                        "*": [
+                            "abi",
+                            "devdoc",
+                            "userdoc",
+                            "evm.bytecode",
+                            "evm.deployedBytecode",
+                            "evm.deployedBytecode.sourceMap",
+                        ],
+                        "": ["ast"],
+                    }
+                }
+            },
+        }
 
     def compile(self, crytic_compile: "CryticCompile", **kwargs: str) -> None:
         """Compile the target
@@ -75,7 +75,7 @@ class VyperStandardJson(AbstractPlatform):
         compilation_artifacts = None
         with tempfile.NamedTemporaryFile(mode="a+") as f:
             json.dump(self.standard_json_input, f)
-            f.seek(0)
+            f.flush()
             compilation_artifacts = _run_vyper_standard_json(f.name, vyper_bin)
 
         if "errors" in compilation_artifacts:

--- a/scripts/ci_test_vyper.sh
+++ b/scripts/ci_test_vyper.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+### Test vyper integration
+
+pip install vyper
+
+echo "Testing vyper integration of $(realpath "$(which crytic-compile)")"
+
+cd tests/vyper || exit 255
+
+if ! crytic-compile auction.vy
+then echo "vyper test failed" && exit 255
+else echo "vyper test passed" && exit 0
+fi

--- a/scripts/ci_test_vyper.sh
+++ b/scripts/ci_test_vyper.sh
@@ -8,7 +8,7 @@ echo "Testing vyper integration of $(realpath "$(which crytic-compile)")"
 
 cd tests/vyper || exit 255
 
-if ! crytic-compile auction.vy
+if ! crytic-compile auction.vy --export-formats standard
 then echo "vyper test failed" && exit 255
 else echo "vyper test passed" && exit 0
 fi

--- a/tests/vyper/auction.vy
+++ b/tests/vyper/auction.vy
@@ -1,0 +1,178 @@
+# Taken from https://github.com/vyperlang/vyper/blob/9136169468f317a53b4e7448389aa315f90b95ba/examples/auctions/blind_auction.vy
+# Blind Auction. Adapted to Vyper from [Solidity by Example](https://github.com/ethereum/solidity/blob/develop/docs/solidity-by-example.rst#blind-auction-1)
+
+struct Bid:
+  blindedBid: bytes32
+  deposit: uint256
+
+# Note: because Vyper does not allow for dynamic arrays, we have limited the
+# number of bids that can be placed by one address to 128 in this example
+MAX_BIDS: constant(int128) = 128
+
+# Event for logging that auction has ended
+event AuctionEnded:
+    highestBidder: address
+    highestBid: uint256
+
+# Auction parameters
+beneficiary: public(address)
+biddingEnd: public(uint256)
+revealEnd: public(uint256)
+
+# Set to true at the end of auction, disallowing any new bids
+ended: public(bool)
+
+# Final auction state
+highestBid: public(uint256)
+highestBidder: public(address)
+
+# State of the bids
+bids: HashMap[address, Bid[128]]
+bidCounts: HashMap[address, int128]
+
+# Allowed withdrawals of previous bids
+pendingReturns: HashMap[address, uint256]
+
+
+# Create a blinded auction with `_biddingTime` seconds bidding time and
+# `_revealTime` seconds reveal time on behalf of the beneficiary address
+# `_beneficiary`.
+@external
+def __init__(_beneficiary: address, _biddingTime: uint256, _revealTime: uint256):
+    self.beneficiary = _beneficiary
+    self.biddingEnd = block.timestamp + _biddingTime
+    self.revealEnd = self.biddingEnd + _revealTime
+
+
+# Place a blinded bid with:
+#
+# _blindedBid = keccak256(concat(
+#       convert(value, bytes32),
+#       convert(fake, bytes32),
+#       secret)
+# )
+#
+# The sent ether is only refunded if the bid is correctly revealed in the
+# revealing phase. The bid is valid if the ether sent together with the bid is
+# at least "value" and "fake" is not true. Setting "fake" to true and sending
+# not the exact amount are ways to hide the real bid but still make the
+# required deposit. The same address can place multiple bids.
+@external
+@payable
+def bid(_blindedBid: bytes32):
+    # Check if bidding period is still open
+    assert block.timestamp < self.biddingEnd
+
+    # Check that payer hasn't already placed maximum number of bids
+    numBids: int128 = self.bidCounts[msg.sender]
+    assert numBids < MAX_BIDS
+
+    # Add bid to mapping of all bids
+    self.bids[msg.sender][numBids] = Bid({
+        blindedBid: _blindedBid,
+        deposit: msg.value
+        })
+    self.bidCounts[msg.sender] += 1
+
+
+# Returns a boolean value, `True` if bid placed successfully, `False` otherwise.
+@internal
+def placeBid(bidder: address, _value: uint256) -> bool:
+    # If bid is less than highest bid, bid fails
+    if (_value <= self.highestBid):
+        return False
+
+    # Refund the previously highest bidder
+    if (self.highestBidder != empty(address)):
+        self.pendingReturns[self.highestBidder] += self.highestBid
+
+    # Place bid successfully and update auction state
+    self.highestBid = _value
+    self.highestBidder = bidder
+
+    return True
+
+
+# Reveal your blinded bids. You will get a refund for all correctly blinded
+# invalid bids and for all bids except for the totally highest.
+@external
+def reveal(_numBids: int128, _values: uint256[128], _fakes: bool[128], _secrets: bytes32[128]):
+    # Check that bidding period is over
+    assert block.timestamp > self.biddingEnd
+
+    # Check that reveal end has not passed
+    assert block.timestamp < self.revealEnd
+
+    # Check that number of bids being revealed matches log for sender
+    assert _numBids == self.bidCounts[msg.sender]
+
+    # Calculate refund for sender
+    refund: uint256 = 0
+    for i in range(MAX_BIDS):
+        # Note that loop may break sooner than 128 iterations if i >= _numBids
+        if (i >= _numBids):
+            break
+
+        # Get bid to check
+        bidToCheck: Bid = (self.bids[msg.sender])[i]
+
+        # Check against encoded packet
+        value: uint256 = _values[i]
+        fake: bool = _fakes[i]
+        secret: bytes32 = _secrets[i]
+        blindedBid: bytes32 = keccak256(concat(
+            convert(value, bytes32),
+            convert(fake, bytes32),
+            secret
+        ))
+
+        # Bid was not actually revealed
+        # Do not refund deposit
+        assert blindedBid == bidToCheck.blindedBid
+
+        # Add deposit to refund if bid was indeed revealed
+        refund += bidToCheck.deposit
+        if (not fake and bidToCheck.deposit >= value):
+            if (self.placeBid(msg.sender, value)):
+                refund -= value
+
+        # Make it impossible for the sender to re-claim the same deposit
+        zeroBytes32: bytes32 = empty(bytes32)
+        bidToCheck.blindedBid = zeroBytes32
+
+    # Send refund if non-zero
+    if (refund != 0):
+        send(msg.sender, refund)
+
+
+# Withdraw a bid that was overbid.
+@external
+def withdraw():
+    # Check that there is an allowed pending return.
+    pendingAmount: uint256 = self.pendingReturns[msg.sender]
+    if (pendingAmount > 0):
+        # If so, set pending returns to zero to prevent recipient from calling
+        # this function again as part of the receiving call before `transfer`
+        # returns (see the remark above about conditions -> effects ->
+        # interaction).
+        self.pendingReturns[msg.sender] = 0
+
+        # Then send return
+        send(msg.sender, pendingAmount)
+
+
+# End the auction and send the highest bid to the beneficiary.
+@external
+def auctionEnd():
+    # Check that reveal end has passed
+    assert block.timestamp > self.revealEnd
+
+    # Check that auction has not already been marked as ended
+    assert not self.ended
+
+    # Log auction ending and set flag
+    log AuctionEnded(self.highestBidder, self.highestBid)
+    self.ended = True
+
+    # Transfer funds to beneficiary
+    send(self.beneficiary, self.highestBid)


### PR DESCRIPTION
## TODO
- [ ] split glob by file extension (`.sol` and `.vy`), create standard json platform, add compilation unit
## Future work
- [ ] identify version of imports and separate into compilation unit by compatibility, duplicating compilation of dependency if two dependents are incompatible
- [ ] make sure Echidna export format `--export-format solc` works
- [ ] support vyper on Etherscan