### PR TITLE
Add more delay on the etherscan CI test

### DIFF
--- a/scripts/ci_test_etherscan.sh
+++ b/scripts/ci_test_etherscan.sh
@@ -12,9 +12,9 @@ delay_etherscan () {
     if [ "$GITHUB_ETHERSCAN" = "" ]; then
         sleep 5s
     else
-      # Always sleep 1 second in the CI
+      # Always sleep 2 second in the CI
       # We have a lot of concurrent github action so this is needed
-      sleep 1s
+      sleep 2s
     fi
 }
 

--- a/scripts/ci_test_etherscan.sh
+++ b/scripts/ci_test_etherscan.sh
@@ -7,10 +7,14 @@ cd "$DIR" || exit 255
 
 solc-select use 0.4.25 --always-install
 
-delay_no_key () {
+delay_etherscan () {
     # Perform a small sleep when API key is not available (e.g. on PR CI from external contributor)
     if [ "$GITHUB_ETHERSCAN" = "" ]; then
         sleep 5s
+    else
+      # Always sleep 1 second in the CI
+      # We have a lot of concurrent github action so this is needed
+      sleep 1s
     fi
 }
 
@@ -24,7 +28,7 @@ then
 fi
 echo "::endgroup::"
 
-delay_no_key
+delay_etherscan
 
 # From crytic/slither#1154
 echo "::group::Etherscan #3"
@@ -37,7 +41,7 @@ then
 fi
 echo "::endgroup::"
 
-delay_no_key
+delay_etherscan
 
 # From crytic/crytic-compile#415
 echo "::group::Etherscan #4"
@@ -50,7 +54,7 @@ then
 fi
 echo "::endgroup::"
 
-delay_no_key
+delay_etherscan
 
 # From crytic/crytic-compile#150
 echo "::group::Etherscan #5"
@@ -69,6 +73,8 @@ then
     esac
 fi
 echo "::endgroup::"
+
+delay_etherscan
 
 # From crytic/crytic-compile#151
 echo "::group::Etherscan #6"

--- a/tests/vyper/auction.vy
+++ b/tests/vyper/auction.vy
@@ -37,6 +37,11 @@ pendingReturns: HashMap[address, uint256]
 # Create a blinded auction with `_biddingTime` seconds bidding time and
 # `_revealTime` seconds reveal time on behalf of the beneficiary address
 # `_beneficiary`.
+@external
+def __init__(_beneficiary: address, _biddingTime: uint256, _revealTime: uint256):
+    self.beneficiary = _beneficiary
+    self.biddingEnd = block.timestamp + _biddingTime
+    self.revealEnd = self.biddingEnd + _revealTime
 
 
 # Place a blinded bid with:

--- a/tests/vyper/auction.vy
+++ b/tests/vyper/auction.vy
@@ -37,11 +37,6 @@ pendingReturns: HashMap[address, uint256]
 # Create a blinded auction with `_biddingTime` seconds bidding time and
 # `_revealTime` seconds reveal time on behalf of the beneficiary address
 # `_beneficiary`.
-@external
-def __init__(_beneficiary: address, _biddingTime: uint256, _revealTime: uint256):
-    self.beneficiary = _beneficiary
-    self.biddingEnd = block.timestamp + _biddingTime
-    self.revealEnd = self.biddingEnd + _revealTime
 
 
 # Place a blinded bid with:


### PR DESCRIPTION
We keep having failing CI because of the etherscan rate limit, which slow the merge of PRs (ex: https://github.com/crytic/crytic-compile/pull/452)