### PR TITLE
deprecate ropsten and kovan etherscan support

### DIFF
--- a/crytic_compile/platform/etherscan.py
+++ b/crytic_compile/platform/etherscan.py
@@ -35,8 +35,6 @@ SUPPORTED_NETWORK = {
     # Key, (prefix_base, perfix_bytecode)
     "mainet:": (".etherscan.io", "etherscan.io"),
     "optim:": ("-optimistic.etherscan.io", "optimistic.etherscan.io"),
-    "ropsten:": ("-ropsten.etherscan.io", "ropsten.etherscan.io"),
-    "kovan:": ("-kovan.etherscan.io", "kovan.etherscan.io"),
     "goerli:": ("-goerli.etherscan.io", "goerli.etherscan.io"),
     "sepolia:": ("-sepolia.etherscan.io", "sepolia.etherscan.io"),
     "tobalaba:": ("-tobalaba.etherscan.io", "tobalaba.etherscan.io"),


### PR DESCRIPTION
closes https://github.com/crytic/crytic-compile/issues/418