### PR TITLE
SolcStandardJson: pass solc_env and solc_working_dir through to compilation

### DIFF
--- a/crytic_compile/platform/solc_standard_json.py
+++ b/crytic_compile/platform/solc_standard_json.py
@@ -437,7 +437,7 @@ class SolcStandardJson(Solc):
         Args:
             crytic_compile (CryticCompile): Associated CryticCompile object
             **kwargs: optional arguments. Used: "solc", "solc_disable_warnings", "solc_args", "solc_working_dir",
-                "solc_remaps"
+                "solc_remaps", "solc_env"
         """
 
         solc: str = kwargs.get("solc", "solc")
@@ -446,12 +446,13 @@ class SolcStandardJson(Solc):
 
         solc_remaps: Optional[Union[str, List[str]]] = kwargs.get("solc_remaps", None)
         solc_working_dir: Optional[str] = kwargs.get("solc_working_dir", None)
+        solc_env: Optional[Dict] = kwargs.get("solc_env", None)
 
         compilation_unit = CompilationUnit(crytic_compile, "standard_json")
 
         compilation_unit.compiler_version = CompilerVersion(
             compiler="solc",
-            version=get_version(solc, None),
+            version=get_version(solc, solc_env),
             optimized=is_optimized(solc_arguments),
         )
 

--- a/crytic_compile/platform/solc_standard_json.py
+++ b/crytic_compile/platform/solc_standard_json.py
@@ -4,15 +4,20 @@ Handle compilation through the standard solc json format
 import json
 import logging
 import os
-from pathlib import Path
 import shutil
 import subprocess
-from typing import TYPE_CHECKING, Dict, List, Optional, Union, Any
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Union
 
 from crytic_compile.compilation_unit import CompilationUnit
 from crytic_compile.compiler.compiler import CompilerVersion
 from crytic_compile.platform.exceptions import InvalidCompilation
-from crytic_compile.platform.solc import Solc, get_version, is_optimized, relative_to_short
+from crytic_compile.platform.solc import (
+    Solc,
+    get_version,
+    is_optimized,
+    relative_to_short,
+)
 from crytic_compile.platform.types import Type
 from crytic_compile.utils.naming import convert_filename
 
@@ -160,7 +165,6 @@ def run_solc_standard_json(
         " ".join(cmd),
     )
     try:
-
         with subprocess.Popen(
             cmd,
             stdin=subprocess.PIPE,
@@ -170,7 +174,6 @@ def run_solc_standard_json(
             executable=shutil.which(cmd[0]),
             **additional_kwargs,
         ) as process:
-
             stdout_b, stderr_b = process.communicate(json.dumps(solc_input).encode("utf-8"))
             stdout, stderr = (
                 stdout_b.decode(),
@@ -453,7 +456,9 @@ class SolcStandardJson(Solc):
         compilation_unit.compiler_version = CompilerVersion(
             compiler="solc",
             version=get_version(solc, solc_env),
-            optimized=is_optimized(solc_arguments),
+            optimized=is_optimized(solc_arguments)
+            or self.to_dict().get("settings", {}).get("optimizer", {}).get("enabled", False),
+            optimize_runs=self.to_dict().get("settings", {}).get("optimizer", {}).get("runs", None),
         )
 
         add_optimization(

--- a/crytic_compile/platform/solc_standard_json.py
+++ b/crytic_compile/platform/solc_standard_json.py
@@ -474,6 +474,7 @@ class SolcStandardJson(Solc):
             self.to_dict(),
             compilation_unit.compiler_version,
             solc_disable_warnings=solc_disable_warnings,
+            working_dir=solc_working_dir,
         )
 
         parse_standard_json_output(


### PR DESCRIPTION
- Adds an optional kwarg to the SolcStandardJson platform so you can specify the solc version. Otherwise, it runs whichever solc version is currently active.
- pass the solc_working_dir variable through to compilation