### PR TITLE
Fix Python 3.12 compatibility

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,15 @@ jobs:
           # Explore foundry support in windows
           - os: windows-2022
             type: foundry
+          # Deprecation alerts in vyper with newer python, which trip tests
+          - python: 3.12
+            type: vyper
+          # brownie does not install correctly with Python 3.12
+          - python: 3.12
+            type: brownie
+          # TODO: review failure executing npx on Windows
+          - os: windows-2022
+            python: 3.12
     steps:
     - uses: actions/checkout@v4
     - name: Set up shell

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,7 @@ jobs:
       fail-fast: false
       matrix:
         os: ["ubuntu-latest", "windows-2022"]
+        python: ${{ (github.event_name == 'pull_request' && fromJSON('["3.8", "3.12"]')) || fromJSON('["3.8", "3.9", "3.10", "3.11", "3.12"]') }}
         type: ["brownie", "buidler", "dapp", "embark", "hardhat", "solc", "truffle", "waffle", "foundry", "standard", "vyper", "solc_multi_file", "hardhat_multi_file"]
         exclude:
           # Currently broken, tries to pull git:// which is blocked by GH
@@ -43,10 +44,10 @@ jobs:
       uses: actions/setup-node@v4
       with:
         node-version: 18.15
-    - name: Set up Python 3.8
+    - name: Set up Python ${{ matrix.python }}
       uses: actions/setup-python@v4
       with:
-        python-version: 3.8
+        python-version: ${{ matrix.python }}
     - name: Install dependencies
       run: |
         pip install "solc-select>=v1.0.0b1"

--- a/crytic_compile/__main__.py
+++ b/crytic_compile/__main__.py
@@ -2,13 +2,12 @@
 This is the Slither cli script
 """
 import argparse
+from importlib.metadata import version
 import json
 import logging
 import os
 import sys
 from typing import TYPE_CHECKING, Any, Optional
-
-from pkg_resources import require
 
 from crytic_compile.crytic_compile import compile_all, get_platforms
 from crytic_compile.cryticparser import DEFAULTS_FLAG_IN_CONFIG, cryticparser
@@ -109,7 +108,7 @@ see https://github.com/crytic/crytic-compile/wiki""",
     parser.add_argument(
         "--version",
         help="displays the current version",
-        version=require("crytic-compile")[0].version,
+        version=version("crytic-compile"),
         action="version",
     )
 


### PR DESCRIPTION
setuptools is no longer bundled: https://github.com/python/cpython/issues/95299

We can use importlib from the standard library on Python 3.8+ instead. This also adds Python 3.12 into the test matrix to avoid further issues into the future.