### PR TITLE
ci: re-enable testing on Windows with Python 3.12

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,9 +36,6 @@ jobs:
           # brownie does not install correctly with Python 3.12
           - python: 3.12
             type: brownie
-          # TODO: review failure executing npx on Windows
-          - os: windows-2022
-            python: 3.12
     steps:
     - uses: actions/checkout@v4
     - name: Set up shell

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,9 @@ setup(
     author="Trail of Bits",
     version="0.3.4",
     packages=find_packages(),
-    python_requires=">=3.8",
+    # Python 3.12.0 on Windows suffers from https://github.com/python/cpython/issues/109590
+    # breaking some of our integrations. The issue is fixed in 3.12.1
+    python_requires=">=3.8,!=3.12.0",
     install_requires=["pycryptodome>=3.4.6", "cbor2", "solc-select>=v1.0.4", "toml>=0.10.2"],
     extras_require={
         "test": [


### PR DESCRIPTION
Python 3.12.0 on Windows suffers from https://github.com/python/cpython/issues/109590 breaking some of our integrations. The issue is fixed in 3.12.1