### PR TITLE
feat: PoC of auto-generating solc-remaps file (for Etherscan Platform)

### DIFF
--- a/crytic_compile/platform/etherscan.py
+++ b/crytic_compile/platform/etherscan.py
@@ -424,6 +424,51 @@ class Etherscan(AbstractPlatform):
             via_ir=via_ir_enabled,
         )
 
+        # Process filenames in target compilationUnit to build solc_remaps.txt
+        remaps = self.solc_remaps_generator(compilation_unit)
+
+        # Convert to string to use with crytic-compile Target.sol --solc-remaps $(cat solc_remaps.txt)
+        remaps_str = ",".join(remaps)
+        with open(os.path.join(working_dir, "solc_remaps.txt"), "w") as f:
+            f.write(f'"{remaps_str}"')
+
+    def solc_remaps_generator(self, compilationTarget: CompilationUnit) -> List[str]:
+        """Generate remapings for --solc-remaps argument. Uses absolute paths.
+
+        Args:
+            compilationTarget (CompilationUnit): current compilation target
+
+        Returns:
+            List[str]: List of remappings deduced from filenames and compilationUnit.source_units
+        """
+        solc_remaps = []
+        processed_remaps = set()  # Avoid duplicates
+        source_units = compilationTarget.source_units
+        for filename, source_unit in source_units.items():
+            short_name = filename.short
+            if short_name.startswith("@"):
+                remap_name = short_name.split("/", 1)[0]
+
+                # Skip if this remap_name has already been processed
+                if remap_name in processed_remaps:
+                    continue
+
+                remap_path = filename.absolute
+
+                # Extract the path up to and including the remap_name directory
+                remap_index = remap_path.find(remap_name + "/")
+                if remap_index != -1:
+                    remap_path = remap_path[: remap_index + len(remap_name)]
+
+                print(f"{remap_name}={remap_path}")
+
+                solc_remaps.append(f"{remap_name}={remap_path}")
+
+                # Mark this remap_name as processed
+                processed_remaps.add(remap_name)
+
+        return solc_remaps
+
     def clean(self, **_kwargs: str) -> None:
         pass
 


### PR DESCRIPTION
Related: https://github.com/crytic/crytic-compile/issues/543

PoC as it only deals with the most common scenario when relative imports were originally structured around @package-name. For foundry projects it's most common to specify remappings string without the "@" and there are also more messier examples in the wild. I think it should be possible to cover most of them though.

What does it do?

After downloading and compiling code with the use of Etherscan platform it will output `solc_remaps.txt` file with "_guessed_" remappings strings, built out of absolute paths used internally by crytic-compile at first download. Then, it will save the file to the working directory of project (downloaded files) 

How to use?

No additional command is needed. Run crytic-compile as usual with address on the network as the target. After it finishes

`cd` into the root of downloaded project _(crytic-export/etherscan-contracts/0x1-Test)_ and run:

 `crytic-compile contracts/Target.sol --solc-remaps $(cat solc_remaps.txt)` 