### PR TITLE
Improve handling of "version" string from Etherscan

### DIFF
--- a/crytic_compile/platform/etherscan.py
+++ b/crytic_compile/platform/etherscan.py
@@ -476,7 +476,7 @@ def _convert_version(version: str) -> str:
     """
     if "+" in version:
         return version[1 : version.find("+")]
-    return version[1 : ]
+    return version[1:]
 
 
 def _sanitize_remappings(

--- a/crytic_compile/platform/etherscan.py
+++ b/crytic_compile/platform/etherscan.py
@@ -476,7 +476,7 @@ def _convert_version(version: str) -> str:
     """
     if "+" in version:
         return version[1 : version.find("+")]
-    return version
+    return version[1 : ]
 
 
 def _sanitize_remappings(

--- a/crytic_compile/platform/etherscan.py
+++ b/crytic_compile/platform/etherscan.py
@@ -474,7 +474,9 @@ def _convert_version(version: str) -> str:
     Returns:
         str: converted version
     """
-    return version[1 : version.find("+")]
+    if "+" in version:
+        return version[1 : version.find("+")]
+    return version
 
 
 def _sanitize_remappings(


### PR DESCRIPTION
crytic-compile fails to compile correctly contracts such as:

```
$ crytic-compile optim:0x7f5c764cbc14f9669b88837ca1490cca17c31607
Traceback (most recent call last):
  File "/home/g/.local/bin/crytic-compile", line 8, in <module>
    sys.exit(main())
  File "/home/g/.local/lib/python3.10/site-packages/crytic_compile/__main__.py", line 221, in main
    compilations = compile_all(**vars(args))
  File "/home/g/.local/lib/python3.10/site-packages/crytic_compile/crytic_compile.py", line 718, in compile_all
    compilations.append(CryticCompile(target, **kwargs))
  File "/home/g/.local/lib/python3.10/site-packages/crytic_compile/crytic_compile.py", line 207, in __init__
    self._compile(**kwargs)
  File "/home/g/.local/lib/python3.10/site-packages/crytic_compile/crytic_compile.py", line 629, in _compile
    self._platform.compile(self, **kwargs)
  File "/home/g/.local/lib/python3.10/site-packages/crytic_compile/platform/etherscan.py", line 356, in compile
    compiler_version = re.findall(
IndexError: list index out of range
```

This is caused by the fact that the compiler version is `v0.7.6`, which does not contain any `+`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Bug Fixes**
	- Improved handling of version identifiers containing special characters for accurate processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->