### PR TITLE
Stop removing spaces in ABI

### DIFF
--- a/crytic_compile/platform/solc.py
+++ b/crytic_compile/platform/solc.py
@@ -43,7 +43,6 @@ def _build_contract_data(compilation_unit: "CompilationUnit") -> Dict:
             abi = abi.replace("'", '"')
             abi = abi.replace("True", "true")
             abi = abi.replace("False", "false")
-            abi = abi.replace(" ", "")
             exported_name = combine_filename_name(filename.absolute, contract_name)
             contracts[exported_name] = {
                 "srcmap": ";".join(source_unit.srcmap_init(contract_name)),


### PR DESCRIPTION
This was causing issues in medusa where geth was unable to parse `contractContractName` when it was expecting `contract ContractName`
see https://github.com/ethereum/go-ethereum/blob/c8c8d6c4039a476478dfcfb732ba83822b648288/accounts/abi/type.go#L222-L227 for the parser code