### PR TITLE
platform: foundry: improve targeted compilations, skips

### DIFF
--- a/crytic_compile/platform/foundry.py
+++ b/crytic_compile/platform/foundry.py
@@ -79,8 +79,8 @@ class Foundry(AbstractPlatform):
                 if foundry_config:
                     compilation_command += [
                         "--skip",
-                        f"*/{foundry_config.tests_path}/**",
-                        f"*/{foundry_config.scripts_path}/**",
+                        f"./{foundry_config.tests_path}/**",
+                        f"./{foundry_config.scripts_path}/**",
                         "--force",
                     ]
 


### PR DESCRIPTION
Currently, if a Foundry user calls `crytic-compile src/Counter.sol`, we collect some compiler configuration information from Foundry and invoke solc manually. This is suboptimal and can lead to different bytecodes being used on e.g. Foundry tests vs Echidna / Medusa fuzzing campaigns. Instead, this PR implements a solution that calls Foundry with the target path and lets it handle the selective compilation process.

This also fixes the skip patterns on full builds to avoid issues when the project folder itself has a parent directory named e.g. `test` or `script`, by taking advantage of the new relative path feature in Foundry.