### PR TITLE
fix: sort Foundry sources by ID for correct sourceList ordering

### DIFF
--- a/crytic_compile/compilation_unit.py
+++ b/crytic_compile/compilation_unit.py
@@ -9,7 +9,7 @@ At least one compilation unit exists for each version of solc used
 import re
 import uuid
 from collections import defaultdict
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, cast
 
 from crytic_compile.compiler.compiler import CompilerVersion
 from crytic_compile.source_unit import SourceUnit
@@ -227,7 +227,7 @@ class CompilationUnit:
                 f"This likely indicates missing sources in build-info."
             )
 
-        return result
+        return cast(list[Filename], result)
 
     def set_source_id(self, source_id: int, filename: Filename) -> None:
         """Set the source ID for a filename.

--- a/crytic_compile/compilation_unit.py
+++ b/crytic_compile/compilation_unit.py
@@ -198,9 +198,10 @@ class CompilationUnit:
         if not self._source_id_to_filename:
             return self._filenames
 
-        # Build list indexed by source ID
+        # Build list indexed by source ID; +1 because IDs are zero-indexed
         max_id = max(self._source_id_to_filename.keys())
-        result: list[Filename | None] = [None] * (max_id + 1)
+        size = max(max_id + 1, len(self._filenames))
+        result: list[Filename | None] = [None] * size
 
         for source_id, filename in self._source_id_to_filename.items():
             result[source_id] = filename
@@ -215,11 +216,18 @@ class CompilationUnit:
                 try:
                     result[i] = next(unmapped_iter)
                 except StopIteration:
-                    # No more unmapped filenames, leave as None (will be filtered)
-                    pass
+                    break
 
-        # Filter out None entries and return
-        return [f for f in result if f is not None]
+        # Gaps in the source ID sequence mean the build-info is incomplete;
+        # exporting with shifted indices would silently produce wrong source maps
+        gaps = [i for i, f in enumerate(result) if f is None]
+        if gaps:
+            raise ValueError(
+                f"Source ID gaps at indices {gaps} — cannot produce correct sourceList. "
+                f"This likely indicates missing sources in build-info."
+            )
+
+        return result
 
     def set_source_id(self, source_id: int, filename: Filename) -> None:
         """Set the source ID for a filename.

--- a/crytic_compile/platform/hardhat.py
+++ b/crytic_compile/platform/hardhat.py
@@ -95,7 +95,14 @@ def hardhat_like_parsing(
             ]
 
             if "sources" in targets_json:
-                for path, info in targets_json["sources"].items():
+                # Sort sources by ID to ensure correct processing order
+                sources_with_ids = [
+                    (path, info, info.get("id"))
+                    for path, info in targets_json["sources"].items()
+                ]
+                sources_with_ids.sort(key=lambda x: x[2] if x[2] is not None else float("inf"))
+
+                for original_path, info, source_id in sources_with_ids:
                     if skip_filename:
                         path = convert_filename(
                             target,
@@ -104,7 +111,7 @@ def hardhat_like_parsing(
                             working_dir=working_dir,
                         )
                     else:
-                        path = process_hardhat_v3_filename(path)
+                        path = process_hardhat_v3_filename(original_path)
 
                         path = convert_filename(
                             path,
@@ -119,6 +126,10 @@ def hardhat_like_parsing(
                         raise InvalidCompilation(
                             f"AST not found for {path} in {build_info} directory"
                         )
+
+                    # Store source ID mapping for correct export ordering
+                    if source_id is not None:
+                        compilation_unit.set_source_id(source_id, path)
 
             if "contracts" in targets_json:
                 for original_filename, contracts_info in targets_json["contracts"].items():

--- a/crytic_compile/platform/hardhat.py
+++ b/crytic_compile/platform/hardhat.py
@@ -97,8 +97,7 @@ def hardhat_like_parsing(
             if "sources" in targets_json:
                 # Sort sources by ID to ensure correct processing order
                 sources_with_ids = [
-                    (path, info, info.get("id"))
-                    for path, info in targets_json["sources"].items()
+                    (path, info, info.get("id")) for path, info in targets_json["sources"].items()
                 ]
                 sources_with_ids.sort(key=lambda x: x[2] if x[2] is not None else float("inf"))
 

--- a/crytic_compile/platform/solc.py
+++ b/crytic_compile/platform/solc.py
@@ -76,7 +76,8 @@ def export_to_solc_from_compilation_unit(
 
     # Create additional informational objects.
     sources = {filename: {"AST": ast} for (filename, ast) in compilation_unit.asts.items()}
-    source_list = [x.absolute for x in compilation_unit.filenames]
+    # Use filenames_for_export to ensure correct source map index ordering
+    source_list = [x.absolute for x in compilation_unit.filenames_for_export]
 
     # Create our root object to contain the contracts and other information.
     output = {"sources": sources, "sourceList": source_list, "contracts": contracts}


### PR DESCRIPTION
Fixes #652

## Summary

When building Foundry projects with subdirectories that use relative paths in their `foundry.toml`, the `sourceList` indices in exported `combined_solc.json` become misaligned with source IDs in bytecode source maps.

## Files Changed

### `compilation_unit.py`
- Add `_source_id_to_filename` dict to track ID→filename mapping
- Add `filenames_for_export` property returning filenames ordered by source ID
- Add `set_source_id()` method to store the mapping

### `hardhat.py`
- Sort sources by ID before processing
- Call `set_source_id()` to store the mapping for each source

### `solc.py`
- Use `filenames_for_export` instead of `filenames` for correct ordering

## Testing

Minimal reproduction: https://github.com/Mike4751/crytic-compile-sourcelist-bug

| Test Case | Unpatched | Patched |
|-----------|-----------|---------|
| Simple project (3 files) | 0 mismatches | 0 mismatches ✓ |
| Relative paths (8 files) | **8 mismatches** | 0 mismatches ✓ |
| Large project (~470 files) | **470 mismatches** | 0 mismatches ✓ |

## Backwards Compatibility

✅ Simple/standard projects continue to work correctly
✅ Complex projects with relative paths are now fixed