### PR TITLE
fix: traverse up to discover compilation framework config

### DIFF
--- a/crytic_compile/crytic_compile.py
+++ b/crytic_compile/crytic_compile.py
@@ -108,6 +108,35 @@ def _configure_solc(solc_requested: str, offline: bool) -> str:
     return solc_path.absolute().as_posix()
 
 
+def _locate_framework_root(
+    working_dir: Path, target: str, **kwargs: str
+) -> tuple[AbstractPlatform | None, Path | None]:
+    """Walk up from ``working_dir`` looking for a non-Solc compilation framework.
+
+    Args:
+        working_dir (Path): starting directory for the upward search
+        target (str): original target passed to CryticCompile (used to instantiate the platform)
+        **kwargs: optional arguments forwarded to ``is_supported``
+
+    Returns:
+        Tuple[Optional[AbstractPlatform], Optional[Path]]: the detected platform and
+        the directory where it was detected, or ``(None, None)`` if no framework was found.
+    """
+    platforms = get_platforms()
+    config_root = working_dir.resolve()
+    while True:
+        platform_wd = next(
+            (p(target) for p in platforms if p.is_supported(str(config_root), **kwargs)),
+            None,
+        )
+        if platform_wd and not isinstance(platform_wd, Solc):
+            return platform_wd, config_root
+        parent = config_root.parent
+        if parent == config_root:
+            return None, None
+        config_root = parent
+
+
 class CryticCompile:
     """
     Main class.
@@ -154,18 +183,17 @@ class CryticCompile:
             # we try to see if we are in a known compilation framework to retrieve
             # information like remappings and solc version
             if isinstance(platform, Solc):
-                # Try to get the platform of the current working directory
-                platform_wd = next(
-                    (
-                        p(target)
-                        for p in get_platforms()
-                        if p.is_supported(str(self._working_dir), **kwargs)
-                    ),
-                    None,
+                # Walk up from the working directory looking for a known
+                # compilation framework (Foundry, Hardhat, ...). This lets
+                # users invoke crytic-compile on a specific file from a
+                # subdirectory of a project and still pick up remappings
+                # and the expected solc version from the project config.
+                platform_wd, config_root = _locate_framework_root(
+                    self._working_dir, target, **kwargs
                 )
                 # If no platform has been found or if it's the Solc platform, we can't automatically compile.
-                if platform_wd and not isinstance(platform_wd, Solc):
-                    platform_config = platform_wd.config(str(self._working_dir))
+                if platform_wd and config_root and not isinstance(platform_wd, Solc):
+                    platform_config = platform_wd.config(str(config_root))
                     if platform_config:
                         kwargs["solc_args"] = ""
                         kwargs["solc_remaps"] = ""

--- a/tests/test_locate_framework_root.py
+++ b/tests/test_locate_framework_root.py
@@ -1,0 +1,54 @@
+"""Tests for _locate_framework_root — the upward platform-discovery helper."""
+
+from pathlib import Path
+
+from crytic_compile.crytic_compile import _locate_framework_root
+from crytic_compile.platform.foundry import Foundry
+from crytic_compile.platform.hardhat import Hardhat
+
+
+def test_hardhat_detected_from_nested_subdirectory(tmp_path: Path) -> None:
+    """A Hardhat project should be detected even when walking up from a
+    nested subdirectory."""
+    (tmp_path / "hardhat.config.js").write_text("module.exports = {};")
+    nested = tmp_path / "contracts" / "tokens"
+    nested.mkdir(parents=True)
+    source = nested / "Token.sol"
+    source.write_text("contract Token {}")
+
+    platform, root = _locate_framework_root(nested, str(source))
+    assert isinstance(platform, Hardhat)
+    assert root == tmp_path.resolve()
+
+
+def test_foundry_detected_from_project_root(tmp_path: Path) -> None:
+    """Foundry should still be detected at the working directory itself."""
+    (tmp_path / "foundry.toml").write_text("[profile.default]\n")
+    source = tmp_path / "src" / "Token.sol"
+    source.parent.mkdir()
+    source.write_text("contract Token {}")
+
+    platform, root = _locate_framework_root(tmp_path, str(source))
+    assert isinstance(platform, Foundry)
+    assert root == tmp_path.resolve()
+
+
+def test_returns_none_when_no_framework_found(tmp_path: Path) -> None:
+    """If no framework exists on the path to /, return (None, None)."""
+    nested = tmp_path / "a" / "b"
+    nested.mkdir(parents=True)
+
+    platform, root = _locate_framework_root(nested, "unused.sol")
+    assert platform is None
+    assert root is None
+
+
+def test_respects_ignore_flag(tmp_path: Path) -> None:
+    """Passing the platform's ignore flag should prevent detection."""
+    (tmp_path / "hardhat.config.js").write_text("module.exports = {};")
+    nested = tmp_path / "contracts"
+    nested.mkdir()
+
+    platform, root = _locate_framework_root(nested, "unused.sol", hardhat_ignore="true")
+    assert platform is None
+    assert root is None


### PR DESCRIPTION
Closes #538.

When the target is a single Solidity file and `crytic-compile` falls back to the `Solc` platform, the code used to check only the working directory for a known compilation framework (Foundry, Hardhat, ...). If the user invoked `crytic-compile` from a subdirectory of their project, the framework was not detected and remappings / solc version were silently dropped.

This walks up the directory tree from the working directory and accepts the first ancestor that matches a non-Solc platform, then passes that directory to `platform.config(...)` so the framework is queried at its actual root.

Foundry already traverses upwards inside `Foundry.locate_project_root`, so it was unaffected. Hardhat/Truffle/Dapp/Brownie/Waffle/Embark/Buidler/Etherlime only check the literal path they're given — those are the cases this change actually fixes.

### Changes
- Extract the detection into a `_locate_framework_root` helper that walks up from the working directory.
- Use the directory where the platform was detected (not the original working directory) when calling `platform.config(...)`, so framework-specific subprocesses (e.g. `forge config --json`) run at the project root.

### Tests
Added `tests/test_locate_framework_root.py` covering:
- Hardhat detection from a nested subdirectory
- Foundry detection at the project root
- `(None, None)` when no framework is present up to `/`
- `hardhat_ignore` kwarg disables detection

Pre-existing `tests/test_library_linking.py` and `tests/test_sourcify_proxy.py` failures on my machine are unrelated (solc binary architecture mismatch in `solc-select`) and reproduce on `master`.