### PR TITLE
foundry: classify dependencies relative to the project root

### DIFF
--- a/crytic_compile/platform/foundry.py
+++ b/crytic_compile/platform/foundry.py
@@ -258,7 +258,15 @@ class Foundry(AbstractPlatform):
         """
         if path in self._cached_dependencies:
             return self._cached_dependencies[path]
-        path_parts = Path(path).parts
+        # Classify the path RELATIVE to the project root, so a file is only a dependency
+        # because of a `lib`/`node_modules`/configured-libs directory *within* the project —
+        # not because the project itself is checked out under a parent directory of that name
+        # (e.g. a git submodule at `<repo>/lib/<project>`, where every absolute source path
+        # would otherwise contain a "lib" component and be wrongly flagged).
+        try:
+            path_parts = Path(path).resolve().relative_to(self._project_root.resolve()).parts
+        except ValueError:
+            path_parts = Path(path).parts  # outside the project tree — classify as-is
         config = self._get_config()
         libs_path = (config.libs_path if config else None) or []
         ret = (

--- a/tests/test_is_dependency.py
+++ b/tests/test_is_dependency.py
@@ -1,0 +1,36 @@
+"""Tests for Foundry.is_dependency — dependency classification must be relative to the
+project root, not fooled by a parent directory that happens to be named `lib`/`node_modules`
+(the normal layout when the project is a git submodule, e.g. ``<repo>/lib/<project>``)."""
+
+from pathlib import Path
+
+from crytic_compile.platform.abstract_platform import PlatformConfig
+from crytic_compile.platform.foundry import Foundry
+
+
+def _make_project(root: Path) -> None:
+    """Create a minimal Foundry project at ``root`` with one source and one lib dependency."""
+    (root / "src").mkdir(parents=True)
+    (root / "foundry.toml").write_text("[profile.default]\n")
+    (root / "src" / "Token.sol").write_text("contract Token {}")
+    (root / "lib" / "solady").mkdir(parents=True)
+    (root / "lib" / "solady" / "Solady.sol").write_text("contract Solady {}")
+
+
+def test_is_dependency_not_fooled_by_parent_lib_directory(tmp_path: Path) -> None:
+    """A project checked out under a parent ``lib/`` directory must still treat its own
+    ``src`` as project code, while its own ``lib/`` contracts remain dependencies."""
+    project = tmp_path / "lib" / "myproject"  # project nested under a parent "lib/"
+    _make_project(project)
+
+    foundry = Foundry(str(project))
+    foundry._config = PlatformConfig()  # avoid spawning `forge config --json`
+
+    src_file = project / "src" / "Token.sol"
+    dep_file = project / "lib" / "solady" / "Solady.sol"
+
+    # Source under a parent "lib/" is NOT a dependency (the bug flags it because the
+    # absolute path contains a "lib" component).
+    assert foundry.is_dependency(str(src_file)) is False
+    # The project's own lib/ contracts ARE dependencies.
+    assert foundry.is_dependency(str(dep_file)) is True


### PR DESCRIPTION
## Summary

`Foundry.is_dependency` classifies a file as a dependency by checking for `lib` / `node_modules` components anywhere in its **absolute** path. When a Foundry project is checked out under a parent directory named `lib` — the normal layout when it's a git submodule (`<repo>/lib/<project>`) — every source file's absolute path contains a `lib` component, so **all of the project's own sources are wrongly flagged as dependencies**.

Dependency-aware consumers then silently skip the whole project. With Slither, the dead-code detector (and other dependency-respecting detectors) report nothing for a project nested under `lib/`, while the same project analyzed as a standalone checkout (e.g. in CI) reports findings — a confusing local-vs-CI divergence with no error.

Fixes #690.

## Change

`is_dependency` now classifies the path **relative to the project root** (`self._project_root`, already on the `Foundry` instance) before the component check, so only `lib` / `node_modules` / configured-libs directories *within* the project count. Paths outside the project tree fall back to the previous behaviour.

```python
try:
    path_parts = Path(path).resolve().relative_to(self._project_root.resolve()).parts
except ValueError:
    path_parts = Path(path).parts  # outside the project tree — classify as-is
```

## Test

Adds `tests/test_is_dependency.py`: a Foundry project created under a parent `lib/` directory, asserting its `src/` is not a dependency while its own `lib/` contracts still are. Fails on `master`, passes with the fix.

## Notes

- Minimal change, no unrelated formatting.
- `ruff check`, `ruff format --check`, and `ty check` all pass.

Related: #279 — same family (dependency path-component detection vs. directory layout), but the opposite failure (dependencies *not found* when hoisted in a monorepo).