### PR TITLE
fix: disable Foundry dynamic test linking

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -147,8 +147,7 @@ Config in `pyproject.toml`:
            """Run build and populate compilation units"""
            ...
 
-       def clean(self, **kwargs: str) -> None:
-           ...
+       def clean(self, **kwargs: str) -> None: ...
 
        def is_dependency(self, path: str) -> bool:
            return "node_modules" in Path(path).parts

--- a/crytic_compile/platform/foundry.py
+++ b/crytic_compile/platform/foundry.py
@@ -126,6 +126,7 @@ class Foundry(AbstractPlatform):
             run(
                 compilation_command,
                 cwd=self._project_root,
+                extra_env={"FOUNDRY_DYNAMIC_TEST_LINKING": "false"},
             )
 
         out_directory_detected = foundry_config.out_path if foundry_config else "out"

--- a/tests/test_foundry.py
+++ b/tests/test_foundry.py
@@ -1,0 +1,24 @@
+"""Tests for the Foundry compilation platform."""
+
+from pathlib import Path
+from unittest import mock
+
+from crytic_compile.platform.abstract_platform import PlatformConfig
+from crytic_compile.platform.foundry import Foundry
+
+
+def test_compile_disables_dynamic_test_linking(tmp_path: Path) -> None:
+    """Foundry builds should disable dynamic test linking through configuration."""
+    (tmp_path / "foundry.toml").write_text("[profile.default]\n", encoding="utf8")
+    platform = Foundry(str(tmp_path))
+    platform._config = PlatformConfig()
+
+    with (
+        mock.patch("crytic_compile.platform.foundry._get_forge_version", return_value=None),
+        mock.patch("crytic_compile.platform.foundry.run") as run,
+        mock.patch("crytic_compile.platform.foundry.hardhat_like_parsing"),
+    ):
+        platform.compile(mock.sentinel.crytic_compile, foundry_compile_all=True)
+
+    assert run.call_args.args[0] == ["forge", "build", "--build-info"]
+    assert run.call_args.kwargs["extra_env"] == {"FOUNDRY_DYNAMIC_TEST_LINKING": "false"}


### PR DESCRIPTION
After v1.7.1  Foundry has enabled dynamic test linking by default. The resulting build contains generated sources that are not portable to Crytic Compile consumers, causing compilation failures with Echidna and Medusa.

This scopes `FOUNDRY_DYNAMIC_TEST_LINKING=false` to the `forge build` subprocess, preserving previous behavior without changing the caller’s environment or project configuration. It remains compatible with Foundry v1.7.1 and earlier, where dynamic test linking is already disabled by default.