### PR TITLE
Parse artifacts after a custom build command

### DIFF
--- a/crytic_compile/crytic_compile.py
+++ b/crytic_compile/crytic_compile.py
@@ -718,11 +718,12 @@ class CryticCompile:
         custom_build: None | str = kwargs.get("compile_custom_build", None)
         if custom_build:
             self._run_custom_build(custom_build)
-
-        else:
-            if not kwargs.get("skip_clean", False) and not kwargs.get("ignore_compile", False):
-                self._platform.clean(**kwargs)
-            self._platform.compile(self, **kwargs)
+            # The custom command already produced the artifacts: let the platform
+            # parse them instead of building again.
+            kwargs = {**kwargs, "ignore_compile": "true"}
+        elif not kwargs.get("skip_clean", False) and not kwargs.get("ignore_compile", False):
+            self._platform.clean(**kwargs)
+        self._platform.compile(self, **kwargs)
 
         # Handle autolink after compilation
         if self._autolink:

--- a/tests/test_custom_build.py
+++ b/tests/test_custom_build.py
@@ -1,0 +1,49 @@
+"""Tests for `--compile-custom-build` (issue #423)."""
+
+from pathlib import Path
+
+from crytic_compile import CryticCompile
+from crytic_compile.platform import Type
+from crytic_compile.platform.abstract_platform import AbstractPlatform
+
+
+class _RecordingPlatform(AbstractPlatform):
+    NAME = "Hardhat"
+    PROJECT_URL = "https://example.invalid"
+    TYPE = Type.HARDHAT
+
+    def __init__(self, target: str, **kwargs: str) -> None:
+        super().__init__(target, **kwargs)
+        self.compile_calls: list[dict] = []
+        self.clean_calls = 0
+
+    def compile(self, crytic_compile: "CryticCompile", **kwargs: str) -> None:
+        self.compile_calls.append(dict(kwargs))
+
+    def clean(self, **kwargs: str) -> None:
+        self.clean_calls += 1
+
+    @staticmethod
+    def is_supported(target: str, **kwargs: str) -> bool:
+        return False
+
+    def is_dependency(self, path: str) -> bool:
+        return False
+
+    def _guessed_tests(self) -> list[str]:
+        return []
+
+
+def test_custom_build_still_parses_artifacts(tmp_path: Path) -> None:
+    marker = tmp_path / "built.txt"
+    platform = _RecordingPlatform(str(tmp_path))
+    CryticCompile(
+        platform,
+        compile_custom_build=f"python3 -c open(r'{marker}','w').write('1')",
+    )
+    assert marker.exists(), "custom build command did not run"
+    assert platform.compile_calls, "platform.compile() was never called: no compilation units"
+    assert platform.compile_calls[0].get("ignore_compile"), (
+        "artifacts were rebuilt instead of parsed"
+    )
+    assert platform.clean_calls == 0, "custom build must not trigger a clean"


### PR DESCRIPTION
Fixes #423.

`--compile-custom-build` runs the user's command, but nothing ever reads what that command produced: `compilation_units` stays empty, so Slither and the other consumers see a project with no sources.

## Cause

In `CryticCompile._compile`, the call that parses the artifacts sits in the `else` branch, so it is skipped whenever a custom build is requested:

```python
custom_build: None | str = kwargs.get("compile_custom_build", None)
if custom_build:
    self._run_custom_build(custom_build)
else:
    if not kwargs.get("skip_clean", False) and not kwargs.get("ignore_compile", False):
        self._platform.clean(**kwargs)
    self._platform.compile(self, **kwargs)   # <- only reached without a custom build
```

## Fix

Every platform already supports `ignore_compile` (`foundry.py`, `hardhat.py`, `buidler.py`, `embark.py`, `truffle.py`): do not invoke the build tool, but still read the artifacts from disk. A custom build has just produced those artifacts, so that is exactly the mode that applies here. The patch reuses it instead of adding a new code path, and no platform is touched.

`ignore_compile` is passed as `"true"` rather than `True` because `**kwargs` is typed `str` here; the platforms only test it for truthiness, and `crytic_defer_compilation` already uses the same string convention.

Cleaning is still skipped for custom builds, which is the previous behaviour.

## Tests

New `tests/test_custom_build.py`. It needs no compiler: it uses a stub `AbstractPlatform`, the same approach as `tests/test_stale_cache_hint.py`. The custom build command writes a marker file, so the test can distinguish "the command did not run" from "the artifacts were not parsed".

Before the fix (the marker assert passes, so the command did run):

```
>       assert platform.compile_calls, "platform.compile() was never called: no compilation units"
E       AssertionError: platform.compile() was never called: no compilation units
E       assert []
1 failed in 0.18s
```

After the fix: `1 passed`.

Also run: `ruff check crytic_compile/ tests/` (clean), `ruff format --check` (clean), `ty check crytic_compile/` (no new diagnostics compared to `master`), and the compiler-independent part of the suite (`test_stale_cache_hint.py`, `test_naming.py`, `test_locate_framework_root.py`) - 25 passed.
