### PR TITLE
Support the object source map returned by vyper 0.4

### DIFF
--- a/crytic_compile/platform/vyper.py
+++ b/crytic_compile/platform/vyper.py
@@ -97,9 +97,11 @@ class VyperStandardJson(AbstractPlatform):
                 ].replace("0x", "")
                 # Vyper does not provide the source mapping for the init bytecode
                 source_unit.srcmaps_init[contract_name] = []
-                source_unit.srcmaps_runtime[contract_name] = contract_metadata["evm"][
-                    "deployedBytecode"
-                ]["sourceMap"].split(";")
+                srcmap_runtime = contract_metadata["evm"]["deployedBytecode"]["sourceMap"]
+                # vyper >= 0.4 returns an object; the solc-style string is `pc_pos_map_compressed`
+                if isinstance(srcmap_runtime, dict):
+                    srcmap_runtime = srcmap_runtime["pc_pos_map_compressed"]
+                source_unit.srcmaps_runtime[contract_name] = srcmap_runtime.split(";")
                 source_unit.bytecodes_runtime[contract_name] = contract_metadata["evm"][
                     "deployedBytecode"
                 ]["object"].replace("0x", "")

--- a/tests/test_vyper.py
+++ b/tests/test_vyper.py
@@ -1,0 +1,42 @@
+"""Tests for the vyper platform."""
+
+import crytic_compile.platform.vyper as vyper_platform
+from crytic_compile import CryticCompile
+
+_VYPER_04_ARTIFACTS = {
+    "compiler": "vyper-0.4.3",
+    "contracts": {
+        "t.vy": {
+            "t": {
+                "abi": [],
+                "userdoc": {},
+                "devdoc": {},
+                "evm": {
+                    "bytecode": {"object": "0x6000"},
+                    "deployedBytecode": {
+                        "object": "0x6000",
+                        "sourceMap": {
+                            "pc_pos_map_compressed": "0:152:0:-;-1:-1:-1",
+                            "pc_pos_map": {},
+                            "pc_jump_map": {},
+                        },
+                    },
+                },
+            }
+        }
+    },
+    "sources": {"t.vy": {"ast": {}, "id": 0}},
+}
+
+
+def test_object_source_map_from_vyper_04(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    target = tmp_path / "t.vy"
+    target.write_text("x: public(uint256)\n", encoding="utf-8")
+    monkeypatch.setattr(
+        vyper_platform, "_run_vyper_standard_json", lambda *a, **k: _VYPER_04_ARTIFACTS
+    )
+    cc = CryticCompile("t.vy")
+    (unit,) = cc.compilation_units.values()
+    (source_unit,) = unit.source_units.values()
+    assert source_unit.srcmaps_runtime["t"] == ["0:152:0:-", "-1:-1:-1"]


### PR DESCRIPTION
Compiling any project with vyper 0.4.x currently crashes:

```
  File "crytic_compile/platform/vyper.py", line 102, in compile
    ]["sourceMap"].split(";")
AttributeError: 'dict' object has no attribute 'split'
```

Since 0.4, vyper returns `evm.deployedBytecode.sourceMap` as an object rather than a string:

```
breakpoints, error_map, pc_ast_map, pc_ast_map_item_keys,
pc_breakpoints, pc_jump_map, pc_pos_map, pc_pos_map_compressed
```

I did not find an existing issue for this, so I am opening the PR directly - happy to file one if you prefer to track it.

## Fix

The same solc-style map is still there, under `pc_pos_map_compressed`:

```
0:152:0:-;-1:-1:-1;-1:-1:-1;...
```

So the fix is to read that key when the compiler hands back an object, and keep the existing path untouched for 0.3.7, where `sourceMap` is a string. This restores real source maps rather than only avoiding the crash.

I kept the change to the source map alone. `compile()` already logs `"Vyper != 0.3.7 support is a best effort and might fail"`, and `scripts/ci_test_vyper.sh` pins `vyper>=0.3.7,<0.4`, so I did not want to claim full 0.4 support in this PR. If you would like the CI script extended to a 0.3.7 + 0.4.x matrix, I am glad to do it here or in a follow-up.

## Tests

New `tests/test_vyper.py`. It needs no vyper binary: `_run_vyper_standard_json` is monkeypatched to return a 0.4-shaped artifact, and the test asserts the resulting `srcmaps_runtime`.

Before the fix:

```
E   AttributeError: 'dict' object has no attribute 'split'
crytic_compile/platform/vyper.py:102
```

After the fix: `1 passed`.

Checked end to end against real compilers as well:

- vyper 0.4.3, a contract using an interface, an event, a default argument, natspec and `staticcall`: 392 source map entries, ABI and AST populated, no crash.
- vyper 0.3.7, `tests/vyper/auction.vy` from this repository: 1858 entries, unchanged.

Also run: `ruff check crytic_compile/ tests/` (clean), `ruff format --check` (clean), `ty check crytic_compile/` (no new diagnostics compared to `master`).
